### PR TITLE
Feat: Profile 사진 첨부 기능 + 스터디/프로젝트 필터로 진행중, 완료 구분 #33

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -16,7 +16,6 @@ export default async function ProfilePage({ searchParams }: ProfilePageProps) {
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 transition-colors duration-300">
-
       <div className="max-w-7xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           <div className="lg:col-span-1">
@@ -29,7 +28,6 @@ export default async function ProfilePage({ searchParams }: ProfilePageProps) {
             searchParams={searchParams}
           />
         </div>
-        <SCProfileContent currentTab={currentTab} searchParams={searchParams} />
       </div>
     </div>
   );

--- a/src/components/profile/CCCreateDropdown.tsx
+++ b/src/components/profile/CCCreateDropdown.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import DefaultButton from "@/components/ui/defaultButton";
+import { cn } from "@/lib/utils";
+
+export default function CCCreateDropdown() {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const closeDropdown = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (dropdownRef.current?.contains(target)) {
+        return;
+      }
+      closeDropdown();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [closeDropdown]);
+
+  return (
+    <div className="relative min-w-24" ref={dropdownRef}>
+      <DefaultButton
+        variant="default"
+        size="sm"
+        className={cn(
+          "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
+          "bg-cert-red border-cert-red hover:bg-cert-red/90 text-white",
+          "focus:ring-2 focus:ring-cert-red/20"
+        )}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex items-center gap-2">
+          <Plus className="w-4 h-4" />
+          <div>새 자료 생성</div>
+        </div>
+      </DefaultButton>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-1 w-full bg-white border border-gray-300 rounded-lg shadow-lg z-20">
+          <Link
+            href="/study/write"
+            className="w-full px-4 py-2 text-left text-gray-900 first:rounded-t-lg text-sm hover:bg-cert-red hover:text-white duration-100 hover:rounded-md items-center gap-2 flex"
+            onClick={closeDropdown}
+          >
+            스터디 생성
+          </Link>
+          <Link
+            href="/project/write"
+            className="w-full px-4 py-2 text-left text-gray-900 last:rounded-b-lg text-sm hover:bg-cert-red hover:text-white duration-100 hover:rounded-md items-center gap-2 flex"
+            onClick={closeDropdown}
+          >
+            프로젝트 생성
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/CCProfilePagination.tsx
+++ b/src/components/profile/CCProfilePagination.tsx
@@ -21,12 +21,14 @@ export default function CCProfilePagination({
 
   const searchParams = useSearchParams();
   const tab = searchParams.get("tab") ?? "study";
+  const status = searchParams.get("status"); // ✅ 추가
 
   const createPageUrl = (page: number): string => {
-    const queryParams = new URLSearchParams({
-      ...(tab && { tab }),
-      ...(page > 1 && { page: page.toString() }),
-    });
+    const queryParams = new URLSearchParams();
+
+    if (tab) queryParams.set("tab", tab);
+    if (tab === "study" && status) queryParams.set("status", status);
+    if (page > 1) queryParams.set("page", page.toString());
 
     return `/profile?${queryParams.toString()}`;
   };

--- a/src/components/profile/CCProfileStudyStatusFilter.tsx
+++ b/src/components/profile/CCProfileStudyStatusFilter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import DefaultButton from "@/components/ui/defaultButton";
+import { studyStatus, StudyStatusType } from "@/types/profile";
+
+interface CCProfileStudyStatusFilterProps {
+  selectedStatus: StudyStatusType;
+}
+
+export default function CCProfileStudyStatusFilter({
+  selectedStatus,
+}: CCProfileStudyStatusFilterProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleCategoryChange = (status: StudyStatusType) => {
+    const params = new URLSearchParams(searchParams);
+
+    if (status === "전체") {
+      params.delete("status");
+    } else {
+      params.set("status", status);
+    }
+    params.delete("page"); // 카테고리 변경 시 첫 페이지로
+
+    const queryString = params.toString();
+    const newUrl = queryString ? `/profile?${queryString}` : "/profile";
+    router.push(newUrl);
+  };
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {studyStatus.map((status) => (
+        <DefaultButton
+          key={status}
+          variant={selectedStatus === status ? "default" : "outline"}
+          size="sm"
+          onClick={() => handleCategoryChange(status)}
+          className={
+            selectedStatus === status
+              ? "category-filter-active"
+              : "category-filter"
+          }
+        >
+          {status}
+        </DefaultButton>
+      ))}
+    </div>
+  );
+}

--- a/src/components/profile/SCProfileContent.tsx
+++ b/src/components/profile/SCProfileContent.tsx
@@ -3,56 +3,92 @@
 import CCTabBar from "@/components/profile/CCTabBar";
 import SCStudyList from "@/components/profile/SCStudyList";
 import SCBlogList from "@/components/profile/SCBlogList";
-import CCProfilePagination from "./CCProfilePagination";
+import CCProfilePagination from "@/components/profile/CCProfilePagination";
 import {
   mockProfileBlogData,
   mockProfileStudyData,
 } from "@/mocks/mockProfileData";
+import { StudyStatusType } from "@/types/profile";
 
 interface SCProfileContentProps {
   currentTab: string;
   searchParams: Promise<{
     tab?: string;
     page?: string;
+    status?: StudyStatusType;
   }>;
 }
-
 export default async function SCProfileContent({
   currentTab,
   searchParams,
 }: SCProfileContentProps) {
-  const { page } = await searchParams;
-
-  const ITEMS_PER_PAGE = 5; // 페이지당 아이템 수
-
+  const { page, status } = await searchParams;
+  const isStudyTab = currentTab === "study";
   const currentPage = parseInt(page || "1", 10);
+
+  const selectedStatus = status ?? "전체";
+
+  const allStudyData = mockProfileStudyData;
+  const allBlogData = mockProfileBlogData;
+
+  let filteredStudyData = allStudyData;
+
+  if (selectedStatus === "진행중") {
+    filteredStudyData = allStudyData
+      .filter((s) => s.status === "진행중")
+      .slice(0, 2);
+  } else if (selectedStatus === "완료") {
+    filteredStudyData = allStudyData.filter((s) => s.status === "완료");
+  } else if (selectedStatus === "전체") {
+    filteredStudyData = allStudyData.sort((a, b) => {
+      if (a.status === b.status) return 0;
+      return a.status === "진행중" ? -1 : 1;
+    });
+  }
+
+  const ITEMS_PER_PAGE = 5;
   const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;
-  const filteredStudyData = mockProfileStudyData;
-  const filteredBlogData = mockProfileBlogData;
-  const paginatedStudyContents = filteredStudyData.slice(startIndex, endIndex);
-  const paginatedBlogContents = filteredBlogData.slice(startIndex, endIndex);
+
+  const paginatedStudyContents =
+    selectedStatus === "진행중"
+      ? filteredStudyData // 스터디+프로젝트 최대 2개
+      : filteredStudyData.slice(startIndex, endIndex);
+
+  const paginatedBlogContents = allBlogData.slice(startIndex, endIndex);
 
   return (
     <div className="lg:col-span-2">
-      {/* 탭 바 */}
       <CCTabBar currentTab={currentTab} />
-      {/* 메인 컨텐츠 */}
-      <SCStudyList
-        searchParams={searchParams}
-        studies={paginatedStudyContents}
-      />
-      <SCBlogList searchParams={searchParams} blogs={paginatedBlogContents} />
 
-      <CCProfilePagination
-        currentPage={currentPage}
-        totalItems={
-          currentTab === "study"
-            ? filteredStudyData.length
-            : filteredBlogData.length
-        }
-        itemsPerPage={ITEMS_PER_PAGE}
-      />
+      {isStudyTab && (
+        <SCStudyList
+          searchParams={searchParams}
+          studies={paginatedStudyContents}
+        />
+      )}
+
+      {!isStudyTab && (
+        <>
+          <SCBlogList
+            searchParams={searchParams}
+            blogs={paginatedBlogContents}
+          />
+          <CCProfilePagination
+            currentPage={currentPage}
+            totalItems={allBlogData.length}
+            itemsPerPage={ITEMS_PER_PAGE}
+          />
+        </>
+      )}
+
+      {isStudyTab && selectedStatus !== "진행중" && (
+        <CCProfilePagination
+          currentPage={currentPage}
+          totalItems={filteredStudyData.length}
+          itemsPerPage={ITEMS_PER_PAGE}
+        />
+      )}
     </div>
   );
 }

--- a/src/mocks/mockProfileData.ts
+++ b/src/mocks/mockProfileData.ts
@@ -27,10 +27,11 @@ export const mockProfileData: ProfileDataType[] = [
 export const mockProfileStudyData: ProfileStudyDataType[] = [
   {
     id: 1,
-    title: "교내 사물함 대여 서비스",
+    title: "교내 사물함 대여 서비스1",
     date: "2024-01-15",
     category: "Project",
     tags: ["React", "Frontend", "JavaScript"],
+    status: "진행중",
   },
   {
     id: 2,
@@ -38,13 +39,15 @@ export const mockProfileStudyData: ProfileStudyDataType[] = [
     date: "2024-01-10",
     category: "Study",
     tags: ["Algorithm", "CodingTest"],
+    status: "진행중",
   },
   {
     id: 3,
-    title: "교내 사물함 대여 서비스",
+    title: "교내 사물함 대여 서비스2",
     date: "2024-01-15",
     category: "Project",
     tags: ["React", "Frontend", "JavaScript"],
+    status: "완료",
   },
   {
     id: 4,
@@ -52,6 +55,7 @@ export const mockProfileStudyData: ProfileStudyDataType[] = [
     date: "2024-01-10",
     category: "Study",
     tags: ["Algorithm", "CodingTest"],
+    status: "완료",
   },
   {
     id: 5,
@@ -59,6 +63,7 @@ export const mockProfileStudyData: ProfileStudyDataType[] = [
     date: "2024-01-15",
     category: "Project",
     tags: ["React", "Frontend", "JavaScript"],
+    status: "완료",
   },
   {
     id: 6,
@@ -66,6 +71,23 @@ export const mockProfileStudyData: ProfileStudyDataType[] = [
     date: "2024-01-10",
     category: "Study",
     tags: ["Algorithm", "CodingTest"],
+    status: "완료",
+  },
+  {
+    id: 7,
+    title: "교내 사물함 대여 서비스3",
+    date: "2024-01-15",
+    category: "Project",
+    tags: ["React", "Frontend", "JavaScript"],
+    status: "완료",
+  },
+  {
+    id: 8,
+    title: "코테 스터디3",
+    date: "2024-01-10",
+    category: "Study",
+    tags: ["Algorithm", "CodingTest"],
+    status: "완료",
   },
 ];
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -19,7 +19,7 @@ export const TAB_CONFIG: Record<
   { label: string; Icon: React.ElementType }
 > = {
   study: {
-    label: "내 스터디",
+    label: "내 스터디 / 프로젝트",
     Icon: BookSVG,
   },
   blog: {
@@ -38,7 +38,12 @@ export interface ProfileStudyDataType {
   date: string;
   category: StudyCategoryType;
   tags: string[];
+  status: string; // "진행중", "완료"
 }
+
+// study, project status category
+export const studyStatus = ["전체", "진행중", "완료"] as const;
+export type StudyStatusType = (typeof studyStatus)[number];
 
 // blog category
 export const BlogCategories = ["개발", "활동", "회고", "기타"] as const;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #33

## 📝작업 내용

> - 프로필 수정에서 사진 첨부가 가능하도록 수정했습니다
> - 스터디/프로젝트에서 진행중/완료가 구분되도록 수정했습니다
> - '새 자료 생성' 버튼을 누르면 드롭다운 형식으로 스터디, 프로젝트 중 선택해서 해당 도메인의 write로 넘어가게끔 구현했습니다


### 스크린샷

https://github.com/user-attachments/assets/947730a3-b4f0-4983-99b8-3dc31b95d0cf
- 드롭다운
<img width="142" height="129" alt="image" src="https://github.com/user-attachments/assets/7550ee4f-a247-4983-9d1d-b2df0ecaaeb7" />

## 💬리뷰 요구사항(선택)

> 피드백 주시면 감사하겠습니다!
