### PR TITLE
Feat: Admin - Study/Project 구현 #45

### DIFF
--- a/src/actions/admin/study/AdminRequestServerAction.tsx
+++ b/src/actions/admin/study/AdminRequestServerAction.tsx
@@ -1,0 +1,18 @@
+"use server";
+import { revalidatePath } from "next/cache";
+
+export async function approveRequest(formData: FormData) {
+  const id = formData.get("id") as string;
+  console.log("승인", id);
+
+  // 페이지 자동 갱신
+  revalidatePath("/admin/study");
+}
+
+export async function rejectRequest(formData: FormData) {
+  const id = formData.get("id") as string;
+  console.log("거절", id);
+
+  // 페이지 자동 갱신
+  revalidatePath("/admin/study");
+}

--- a/src/app/(admin)/admin/study/[id]/page.tsx
+++ b/src/app/(admin)/admin/study/[id]/page.tsx
@@ -1,0 +1,24 @@
+"server-only";
+
+import StudyDetailPage from "@/app/(admin)/admin/study/[id]/studyDetailPage";
+import ProjectDetailPage from "@/app/(admin)/admin/study/[id]/projectDetailPage";
+
+interface AdminStudyDetailPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
+}
+
+export default async function AdminStudyDetailPage({
+  params,
+  searchParams,
+}: AdminStudyDetailPageProps) {
+  const { id } = await params;
+  const { tab } = await searchParams;
+
+  if (tab === "project") {
+    return <ProjectDetailPage params={{ id }} />;
+  }
+  if (tab === "study") {
+    return <StudyDetailPage params={{ id }} />;
+  }
+}

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -1,6 +1,10 @@
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { ProjectMaterial } from "@/types/project";
+import {
+  AUTHOR_STATUS_LABELS,
+  ProjectMaterial,
+  STATUS_LABELS,
+} from "@/types/project";
 import AttachedFilesDownload from "@/components/project/SCAttachedFilesDownload";
 import { Globe, BookText } from "lucide-react";
 import Image from "next/image";
@@ -9,10 +13,9 @@ import BackToListButton from "@/components/detail/SCBackToListButton";
 import KebabMenu from "@/components/detail/CCKebabMenu";
 import ShareButton from "@/components/detail/CCShareButton";
 import { getStatusColor } from "@/utils/projectUtils";
-import { STATUS_LABELS, AUTHOR_STATUS_LABELS } from "@/types/project";
 
 interface ProjectDetailPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 const getProjectById = (id: string): ProjectMaterial | undefined => {
@@ -87,7 +90,7 @@ export default async function ProjectDetailPage({
   return (
     <div className="mx-auto max-w-full bg-white">
       {/* 뒤로가기 버튼 */}
-      <BackToListButton currentUrl="project" />
+      <BackToListButton currentUrl={"admin/study"} />
       <article>
         {/* 프로젝트 이미지 */}
         <div className="relative h-96 mb-8 bg-gradient-to-br from-purple-400 to-indigo-600 overflow-hidden mt-6 rounded-lg">
@@ -229,10 +232,6 @@ export default async function ProjectDetailPage({
               데모 사이트
             </a>
           )}
-
-          <button className="action-button inline-flex items-center gap-2 px-6 py-2">
-            프로젝트 참가하기
-          </button>
         </div>
 
         {/* 첨부파일 섹션 */}

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -16,6 +16,9 @@ import { formatFileSize } from "@/utils/attachedFileUtils";
 import { getFileIcon } from "@/utils/attachedFileUtils";
 import { calculateDDay, getStatusColor } from "@/utils/studyHelper";
 
+interface StudyDetailPageProps {
+  params: { id: string };
+}
 function getStudyDataById(id: string): StudyDetailData | null {
   const parsedId = parseInt(id, 10);
   return mockStudyDetailData.find((data) => data.id === parsedId) || null;
@@ -49,11 +52,9 @@ export async function generateMetadata({
   };
 }
 
-export default async function StudyMaterialDetailPage({
+export default async function StudyDetailPage({
   params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+}: StudyDetailPageProps) {
   const { id } = await params;
   const studyData = getStudyDataById(id);
 
@@ -66,15 +67,12 @@ export default async function StudyMaterialDetailPage({
 
   return (
     <div>
-      {/* Header */}
       <div className="space-y-6">
-        <BackToListButton currentUrl={"study"} />
+        <BackToListButton currentUrl={"admin/study"} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8  mt-6">
-        {/* Main Content */}
         <div className="lg:col-span-2  space-y-6">
-          {/* Study Material Info Card */}
           <div className="bg-white dark:bg-gray-800 p-1 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
             <div className="p-6 pb-0 ">
               <div className="flex items-start  justify-between mb-4">
@@ -101,9 +99,6 @@ export default async function StudyMaterialDetailPage({
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <button className="px-4 py-2 action-button">
-                    스터디 참가하기
-                  </button>
                   <KebabMenu
                     currentId={studyData.id}
                     currentUrl={"study"}
@@ -113,7 +108,6 @@ export default async function StudyMaterialDetailPage({
             </div>
 
             <div className="p-6 space-y-6">
-              {/* Basic Description + Detail Content */}
               <div className="space-y-4">
                 <p className="text-black dark:text-gray-300 leading-relaxed border-b border-gray-200 pb-6">
                   {studyData.description}
@@ -123,7 +117,6 @@ export default async function StudyMaterialDetailPage({
 
               <div className="w-full h-px bg-gray-200 dark:bg-gray-700"></div>
 
-              {/* Study Details */}
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="flex items-center gap-3">
                   <Users className="w-5 h-5 text-cert-red" />

--- a/src/app/(admin)/admin/study/layout.tsx
+++ b/src/app/(admin)/admin/study/layout.tsx
@@ -1,0 +1,26 @@
+import PageLayout from "@/layouts/pageLayout";
+import TerminalSVG from "/public/icons/terminal.svg";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Admin | Study / Project",
+  description: "스터디와 프로젝트를 관리하는 곳입니다.",
+};
+
+export default function AdminStudyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <PageLayout
+        title={"Study / Project"}
+        description={"스터디와 프로젝트를 관리하세요."}
+        icon={<TerminalSVG className="stroke-cert-dark-red w-8 h-8" />}
+      >
+        {children}
+      </PageLayout>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/study/page.tsx
+++ b/src/app/(admin)/admin/study/page.tsx
@@ -1,0 +1,64 @@
+"server-only";
+
+import CCProjectSearchBar from "@/components/project/CCProjectSearchBar";
+import SCStudyContentList from "@/components/admin/study/SCStudyContentList";
+import SCProjectContentList from "@/components/admin/study/SCProjectContentList";
+import CCStudyTabBar from "@/components/admin/study/CCStudyTabBar";
+import {
+  isValidMainTab,
+  isValidSubTab,
+  MainTab,
+  SubTab,
+} from "@/types/admin/adminStudyTab";
+
+interface AdminStudyProps {
+  searchParams: Promise<{
+    search?: string;
+    page?: string;
+    tab?: string;
+    view?: string;
+  }>;
+}
+
+export default async function AdminStudyPage({
+  searchParams,
+}: AdminStudyProps) {
+  const resolvedSearchParams = await searchParams;
+
+  const tabParam = resolvedSearchParams.tab;
+  const viewParam = resolvedSearchParams.view;
+  const pageParam = resolvedSearchParams.page;
+
+  const currentSearch = resolvedSearchParams.search || "";
+  const currentPage = Math.max(1, parseInt(pageParam || "1", 10));
+  const currentTab: MainTab =
+    tabParam && isValidMainTab(tabParam) ? tabParam : "study";
+  const currentView: SubTab =
+    viewParam && isValidSubTab(viewParam) ? viewParam : "pending";
+
+  return (
+    <div>
+      {/* 서치바는 컴포넌트 하나로 만든 뒤 호출해서 사용하는 게 좋을 것 같아서 따로 브랜치 파서 통일시킬게요 */}
+      <CCProjectSearchBar currentSearch={currentSearch} />
+      <CCStudyTabBar currentTab={currentTab} currentView={currentView} />
+
+      {currentTab === "study" && (
+        <SCStudyContentList
+          currentTab={currentTab}
+          currentView={currentView}
+          currentSearch={currentSearch}
+          currentPage={currentPage}
+        />
+      )}
+
+      {currentTab === "project" && (
+        <SCProjectContentList
+          currentTab={currentTab}
+          currentView={currentView}
+          currentSearch={currentSearch}
+          currentPage={currentPage}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/study/CCAdminStudyPagination.tsx
+++ b/src/components/admin/study/CCAdminStudyPagination.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { getPageNumbers } from "@/utils/paginationUtils";
+import { MainTab, SubTab } from "@/types/admin/adminStudyTab";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect } from "react";
+
+interface CCStudyPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  currentSearch: string;
+  currentTab: MainTab;
+  currentView: SubTab;
+}
+
+export default function CCStudyPagination({
+  currentPage,
+  totalPages,
+  currentSearch,
+  currentTab,
+  currentView,
+}: CCStudyPaginationProps) {
+  // 페이지 변경 시 스크롤 제어
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, [currentPage]);
+
+  if (totalPages <= 1) return null;
+
+  const createPageUrl = (page: number) => {
+    const params = new URLSearchParams();
+
+    if (currentSearch) params.set("search", currentSearch);
+    params.set("tab", currentTab);
+    params.set("view", currentView);
+
+    if (page > 1) params.set("page", String(page));
+
+    const query = params.toString();
+    return `/admin/study${query ? `?${query}` : ""}`;
+  };
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+
+  return (
+    <div className="mt-8">
+      <div className="flex justify-center items-center space-x-2 flex-wrap gap-y-2">
+        {/* 이전 페이지 버튼 */}
+        {currentPage > 1 ? (
+          <Link href={createPageUrl(currentPage - 1)}>
+            <div
+              className="p-2 rounded-md transition-all duration-200 text-gray-700 hover:bg-gray-100"
+              title="이전 페이지"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </div>
+          </Link>
+        ) : (
+          <div
+            className="p-2 rounded-md transition-all duration-200 text-gray-400 cursor-not-allowed"
+            title="이전 페이지"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </div>
+        )}
+
+        {/* 페이지 번호들 */}
+        {pageNumbers.map((page, index) => {
+          if (page === "...") {
+            return (
+              <span
+                key={`ellipsis-${index}`}
+                className="w-10 h-10 flex items-center justify-center text-gray-500 text-sm"
+              >
+                ...
+              </span>
+            );
+          }
+
+          const pageNumber = page as number;
+
+          return pageNumber === currentPage ? (
+            <div
+              key={pageNumber}
+              className="w-10 h-10 text-sm font-medium shadow-md flex items-center justify-center rounded-md bg-cert-red text-white border border-cert-red"
+            >
+              {pageNumber}
+            </div>
+          ) : (
+            <Link key={pageNumber} href={createPageUrl(pageNumber)}>
+              <div className="w-10 h-10 text-sm font-medium flex items-center justify-center rounded-md border border-gray-300 text-gray-700 bg-white hover:bg-gray-100 transition-colors">
+                {pageNumber}
+              </div>
+            </Link>
+          );
+        })}
+
+        {/* 다음 페이지 버튼 */}
+        {currentPage < totalPages ? (
+          <Link href={createPageUrl(currentPage + 1)}>
+            <div
+              className="p-2 rounded-md transition-all duration-200 text-gray-700 hover:bg-gray-100"
+              title="다음 페이지"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </div>
+          </Link>
+        ) : (
+          <div
+            className="p-2 rounded-md transition-all duration-200 text-gray-400 cursor-not-allowed"
+            title="다음 페이지"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/study/CCStudyTabBar.tsx
+++ b/src/components/admin/study/CCStudyTabBar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  MAIN_TABS,
+  MainTab,
+  SUB_TABS,
+  SubTab,
+  SUBTAB_CONFIG,
+  TAB_CONFIG,
+} from "@/types/admin/adminStudyTab";
+import { useRouter } from "next/navigation";
+
+interface CCStudyTabBarProps {
+  currentTab: MainTab;
+  currentView: SubTab;
+}
+export default function CCStudyTabBar({
+  currentTab,
+  currentView,
+}: CCStudyTabBarProps) {
+  const router = useRouter();
+
+  const handleMainTabClick = (tab: MainTab) => {
+    const params = new URLSearchParams();
+    params.set("tab", tab);
+    params.set("view", "pending"); // 메인 탭 변경 시 서브 탭 초기화
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  const handleSubTabClick = (view: SubTab) => {
+    const params = new URLSearchParams();
+    params.set("tab", currentTab);
+    params.set("view", view);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-10">
+      <div className="mt-5 grid grid-cols-2 w-full h-10 rounded-md p-1 bg-gray-100 text-muted-foreground">
+        {MAIN_TABS.map((tab) => {
+          const isActive = currentTab === tab;
+          return (
+            <button
+              key={tab}
+              onClick={() => handleMainTabClick(tab)}
+              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all
+                ${
+                  isActive
+                    ? "bg-cert-red text-white shadow-sm"
+                    : "text-gray-500"
+                }`}
+            >
+              {TAB_CONFIG[tab].label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 w-full h-10 rounded-md p-1 bg-gray-100">
+        {SUB_TABS.map((view) => {
+          const isActive = currentView === view;
+          return (
+            <button
+              key={view}
+              onClick={() => handleSubTabClick(view)}
+              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all
+                ${
+                  isActive
+                    ? "bg-cert-red text-white shadow-sm"
+                    : "text-gray-500"
+                }`}
+            >
+              {SUBTAB_CONFIG[view].label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/study/SCProjectContentList.tsx
+++ b/src/components/admin/study/SCProjectContentList.tsx
@@ -1,0 +1,507 @@
+"server-only";
+
+import DefaultBadge from "@/components/ui/defaultBadge";
+import { Calendar, Target, User, Users } from "lucide-react";
+import RequestActionButtons from "@/components/ui/requestActionButtons";
+import { MainTab, SubTab } from "@/types/admin/adminStudyTab";
+import {
+  approveRequest,
+  rejectRequest,
+} from "@/actions/admin/study/AdminRequestServerAction";
+import { isApprovedProject, Project } from "@/types/admin/adminCreateFormData";
+import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
+import TerminalSVG from "/public/icons/terminal.svg";
+import Link from "next/link";
+import PdfSVG from "/public/icons/pdf.svg";
+import DownloadGraySVG from "/public/icons/download-gray.svg";
+import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
+import CCAdminStudyPagination from "./CCAdminStudyPagination";
+
+export const projects: Project[] = [
+  // 승인 대기: 폼에서 제출된 필드만 존재
+  {
+    id: 1,
+    isPending: true,
+    title: "CERT-IS 홈페이지 리뉴얼",
+    description:
+      "Next.js + Tailwind 기반으로 동아리 홈페이지 리뉴얼. 접근성 개선과 Admin 콘솔 추가.",
+    content: `## 목표
+- SSR/ISR 적용으로 초기 로딩 개선
+- Admin 대시보드 구현
+- 접근성(ARIA) 점검
+
+## 기술 스택
+- Next.js, TypeScript, TailwindCSS, Supabase`,
+    category: "프론트엔드",
+    tags: ["Next.js", "Tailwind", "Supabase", "SSR"],
+    attachments: [
+      {
+        id: "file_p1_1",
+        name: "요구사항_정의서.pdf",
+        size: 314572,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/requirements-spec.pdf",
+        uploadDate: "2025-08-10T09:00:00Z",
+        description: "핵심 기능/마감 일정 정리",
+      },
+    ],
+    startDate: "2025-08-25",
+    endDate: "2025-11-30",
+    maxParticipants: "6",
+    githubUrl: "https://github.com/cert-is/renewal",
+    demoUrl: "https://cert-is.dev",
+    externalLinks: [
+      { label: "디자인 시안(Figma)", url: "https://figma.com/file/xyz" },
+      { label: "API 명세서(Notion)", url: "https://notion.so/abc" },
+    ],
+    projectImage: null,
+    author: "김보안",
+    // ✅ pending이라 currentParticipants/progress 없음 (never)
+  },
+
+  // 승인됨: 참가/진행률 필드 허용
+  {
+    id: 2,
+    isPending: false,
+    title: "웹 취약점 자동 스캐너 PoC",
+    description:
+      "OWASP Top 10 중심 경량 스캐너 PoC. False Positive 최소화에 집중.",
+    content: `### 구성
+- 크롤러 → 검사기 → 리포터
+- 모듈형 규칙 엔진 설계`,
+    category: "보안",
+    tags: ["OWASP", "Scanner", "PoC", "Node"],
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "웹 취약점 자동 스캐너 프로젝트_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/scanner_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "웹 취약점 자동 스캐너 PoC",
+      },
+    ],
+    startDate: "2025-09-02",
+    endDate: "2025-10-15",
+    maxParticipants: "4",
+    githubUrl: "https://github.com/cert-is/sec-scanner-poc",
+    demoUrl: "",
+    externalLinks: [
+      { label: "레퍼런스 자료 모음", url: "https://notion.so/ref-sec" },
+    ],
+    projectImage: null,
+    author: "김첨지",
+
+    currentParticipants: 3, // 필수
+    progress: 45, // 선택
+  },
+  {
+    id: 3,
+    isPending: false,
+    title: "웹 취약점 자동 스캐너 PoC",
+    description:
+      "OWASP Top 10 중심 경량 스캐너 PoC. False Positive 최소화에 집중.",
+    content: `### 구성
+- 크롤러 → 검사기 → 리포터
+- 모듈형 규칙 엔진 설계`,
+    category: "보안",
+    tags: ["OWASP", "Scanner", "PoC", "Node"],
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "웹 취약점 자동 스캐너 프로젝트_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/scanner_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "웹 취약점 자동 스캐너 PoC",
+      },
+    ],
+    startDate: "2025-09-02",
+    endDate: "2025-10-15",
+    maxParticipants: "4",
+    githubUrl: "https://github.com/cert-is/sec-scanner-poc",
+    demoUrl: "",
+    externalLinks: [
+      { label: "레퍼런스 자료 모음", url: "https://notion.so/ref-sec" },
+    ],
+    projectImage: null,
+    author: "김첨지",
+
+    currentParticipants: 3, // 필수
+    progress: 45, // 선택
+  },
+  {
+    id: 4,
+    isPending: false,
+    title: "웹 취약점 자동 스캐너 PoC",
+    description:
+      "OWASP Top 10 중심 경량 스캐너 PoC. False Positive 최소화에 집중.",
+    content: `### 구성
+- 크롤러 → 검사기 → 리포터
+- 모듈형 규칙 엔진 설계`,
+    category: "보안",
+    tags: ["OWASP", "Scanner", "PoC", "Node"],
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "웹 취약점 자동 스캐너 프로젝트_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/scanner_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "웹 취약점 자동 스캐너 PoC",
+      },
+    ],
+    startDate: "2025-09-02",
+    endDate: "2025-10-15",
+    maxParticipants: "4",
+    githubUrl: "https://github.com/cert-is/sec-scanner-poc",
+    demoUrl: "",
+    externalLinks: [
+      { label: "레퍼런스 자료 모음", url: "https://notion.so/ref-sec" },
+    ],
+    projectImage: null,
+    author: "김첨지",
+
+    currentParticipants: 3, // 필수
+    progress: 45, // 선택
+  },
+];
+
+interface SCProjectContentListProps {
+  currentTab: MainTab;
+  currentView: SubTab;
+  currentSearch?: string;
+  currentPage?: number;
+}
+
+export default function SCProjectContentList({
+  currentTab,
+  currentView,
+  currentSearch = "",
+  currentPage = 1,
+}: SCProjectContentListProps) {
+  const viewFiltered =
+    currentView === "pending"
+      ? projects.filter((p) => p.isPending)
+      : currentView === "list"
+      ? projects.filter((p) => !p.isPending)
+      : projects;
+
+  const searchFiltered = currentSearch
+    ? viewFiltered.filter(
+        (item) =>
+          item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+          item.description
+            ?.toLowerCase()
+            .includes(currentSearch.toLowerCase()) ||
+          item.author?.toLowerCase().includes(currentSearch.toLowerCase())
+      )
+    : viewFiltered;
+
+  const ITEMS_PER_PAGE = 2;
+  const totalItems = searchFiltered.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+  const validPage = Math.min(currentPage, totalPages);
+  const startIndex = (validPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const paginatedContents = searchFiltered.slice(startIndex, endIndex);
+
+  const totalPending = projects.filter((p) => p.isPending).length;
+  const totalProgress = projects.filter((p) => !p.isPending).length;
+  const pendingUntilCurrentPage = projects
+    .filter((p) => p.isPending)
+    .slice(0, currentPage * ITEMS_PER_PAGE).length;
+
+  const progressUntilCurrentPage = projects
+    .filter((p) => !p.isPending)
+    .slice(0, currentPage * ITEMS_PER_PAGE).length;
+
+  return (
+    <>
+      {currentTab === "project" && currentView === "pending" && (
+        <>
+          <div className="mt-4 text-lg text-gray-600">
+            ✔️ 프로젝트 승인 대기 목록 ({pendingUntilCurrentPage}/{totalPending}
+            )
+          </div>
+
+          {paginatedContents.length === 0 ? (
+            <div className="flex items-center justify-center max-h-screen w-full">
+              <DefaultNoneResultUi
+                icon={<TerminalSVG className="text-cert-dark-red" />}
+                title="검색 결과가 없습니다"
+                description="다른 검색어나 필터를 시도해보세요."
+              />
+            </div>
+          ) : (
+            paginatedContents.map((project) => (
+              <Link
+                key={project.id}
+                href={`/admin/study/${project.id}?tab=project`}
+              >
+                <div key={project.id} className="mt-4 card-list">
+                  {/* 헤더 */}
+                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                    <div className="flex justify-between items-start">
+                      <div className="space-y-3">
+                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                          <div className="text-xl font-medium">
+                            {project.title}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {project.isPending ? (
+                              <DefaultBadge className="bg-red-100 text-red-800">
+                                승인 대기
+                              </DefaultBadge>
+                            ) : (
+                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                                승인됨
+                              </DefaultBadge>
+                            )}
+                            <DefaultBadge className="bg-green-100 text-green-800">
+                              {project.category}
+                            </DefaultBadge>
+                          </div>
+                        </div>
+                        <div className="text-base text-gray-600">
+                          {project.description}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 본문 */}
+                  <div className="p-6 pt-0">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                      <div className="grid grid-cols-1 md:grid-cols-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <User className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              프로젝트장: {project.author}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Users className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              최대 인원: {project.maxParticipants}명
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              {project.startDate} ~ {project.endDate}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
+                      {project.attachments?.map((file, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
+                        >
+                          <div className="flex items-center gap-3">
+                            <PdfSVG className="w-5 h-5 text-red-500" />
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {file.name}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {file.size}
+                              </p>
+                            </div>
+                          </div>
+                          <form action={downloadFile}>
+                            <input
+                              type="hidden"
+                              name="fileName"
+                              value={file.name}
+                            />
+                            <input
+                              type="hidden"
+                              name="projectId"
+                              value={project.id}
+                            />
+                            <button type="submit">
+                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                            </button>
+                          </form>
+                        </div>
+                      ))}
+                      <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
+                        <RequestActionButtons
+                          id={project.id}
+                          approveAction={approveRequest}
+                          rejectAction={rejectRequest}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))
+          )}
+        </>
+      )}
+
+      {currentTab === "project" && currentView === "list" && (
+        <>
+          <div className="mt-4 text-lg text-gray-600">
+            📁 프로젝트 목록 ({progressUntilCurrentPage}/{totalProgress})
+          </div>
+
+          {paginatedContents.length === 0 ? (
+            <div className="flex items-center justify-center max-h-screen w-full">
+              <DefaultNoneResultUi
+                icon={<TerminalSVG className="text-cert-dark-red" />}
+                title="검색 결과가 없습니다"
+                description="다른 검색어나 필터를 시도해보세요."
+              />
+            </div>
+          ) : (
+            paginatedContents.map((project) => (
+              <Link
+                key={project.id}
+                href={`/admin/study/${project.id}?tab=project`}
+              >
+                <div key={project.id} className="mt-4 card-list">
+                  {/* 헤더 */}
+                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                    <div className="flex justify-between items-start">
+                      <div className="space-y-3">
+                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                          <div className="text-xl font-medium">
+                            {project.title}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {project.isPending ? (
+                              <DefaultBadge className="bg-red-100 text-red-800">
+                                승인 대기
+                              </DefaultBadge>
+                            ) : (
+                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                                승인됨
+                              </DefaultBadge>
+                            )}
+                            <DefaultBadge className="bg-green-100 text-green-800">
+                              {project.category}
+                            </DefaultBadge>
+                          </div>
+                        </div>
+                        <div className="text-base text-gray-600">
+                          {project.description}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 본문 */}
+                  <div className="p-6 pt-0">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                      <div className="grid grid-cols-1 md:grid-cols-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <User className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              프로젝트장: {project.author}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Users className="w-4 h-4 text-gray-500" />
+                            {isApprovedProject(project) ? (
+                              <span className="text-sm">
+                                현재 인원: {project.currentParticipants}/
+                                {project.maxParticipants}명
+                              </span>
+                            ) : (
+                              <span className="text-sm">
+                                최대 인원: {project.maxParticipants}명
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              {project.startDate} ~ {project.endDate}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Target className="w-4 h-4 text-gray-500" />
+                            {isApprovedProject(project) && (
+                              <span className="text-sm">
+                                진행률: {project.progress}%
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="space-y-2 mt-4 ">
+                      {project.attachments?.map((file, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
+                        >
+                          <div className="flex items-center gap-3">
+                            <PdfSVG className="w-5 h-5 text-red-500" />
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {file.name}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {file.size}
+                              </p>
+                            </div>
+                          </div>
+                          <form action={downloadFile}>
+                            <input
+                              type="hidden"
+                              name="fileName"
+                              value={file.name}
+                            />
+                            <input
+                              type="hidden"
+                              name="projectId"
+                              value={project.id}
+                            />
+                            <button type="submit">
+                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                            </button>
+                          </form>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))
+          )}
+        </>
+      )}
+      {totalItems > 0 && (
+        <CCAdminStudyPagination
+          currentPage={validPage}
+          totalPages={totalPages}
+          currentSearch={currentSearch}
+          currentTab={currentTab}
+          currentView={currentView}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/admin/study/SCStudyContentList.tsx
+++ b/src/components/admin/study/SCStudyContentList.tsx
@@ -1,0 +1,396 @@
+"server-only";
+
+import DefaultBadge from "@/components/ui/defaultBadge";
+import { Calendar, User, Users, Target } from "lucide-react";
+import RequestActionButtons from "@/components/ui/requestActionButtons";
+import { MainTab, SubTab } from "@/types/admin/adminStudyTab";
+import { Study, isApprovedStudy } from "@/types/admin/adminCreateFormData";
+import {
+  approveRequest,
+  rejectRequest,
+} from "@/actions/admin/study/AdminRequestServerAction";
+import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
+import TerminalSVG from "/public/icons/terminal.svg";
+import Link from "next/link";
+import PdfSVG from "/public/icons/pdf.svg";
+import DownloadGraySVG from "/public/icons/download-gray.svg";
+import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
+import CCAdminStudyPagination from "./CCAdminStudyPagination";
+
+export const studies: Study[] = [
+  {
+    id: 1,
+    isPending: true,
+    title: "OWASP Top 10 스터디",
+    description: "최신 OWASP Top 10을 주차별로 읽고 실습합니다.",
+    content: "상세 소개...",
+    category: "보안/웹",
+    tags: ["OWASP", "웹해킹"],
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "해커톤_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/hackathon_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "해커톤 전체 기획서 및 일정표",
+      },
+    ],
+    startDate: "2025-09-01",
+    endDate: "2025-11-30",
+    maxParticipants: "12",
+    author: "김보안",
+  },
+  {
+    id: 2,
+    isPending: false,
+    title: "프론트엔드 성능 최적화 스터디",
+    description: "렌더링 최적화/번들 분석 등 실무 중심",
+    content: "상세 소개...",
+    category: "프론트엔드",
+    tags: ["React", "Performance"],
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "해커톤_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/hackathon_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "해커톤 전체 기획서 및 일정표",
+      },
+    ],
+    startDate: "2025-08-20",
+    endDate: "2025-10-08",
+    maxParticipants: "8",
+    author: "강찬희",
+    currentParticipants: 5,
+    progress: 70,
+  },
+];
+
+interface SCStudyContentListProps {
+  currentTab: MainTab;
+  currentView: SubTab;
+  currentSearch?: string;
+  currentPage: number;
+}
+
+export default async function SCStudyContentList({
+  currentTab,
+  currentView,
+  currentSearch = "",
+  currentPage = 1,
+}: SCStudyContentListProps) {
+  const viewFiltered =
+    currentView === "pending"
+      ? studies.filter((s) => s.isPending)
+      : currentView === "list"
+      ? studies.filter((s) => !s.isPending)
+      : studies;
+
+  const searchFiltered = currentSearch
+    ? viewFiltered.filter(
+        (item) =>
+          item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+          item.description
+            ?.toLowerCase()
+            .includes(currentSearch.toLowerCase()) ||
+          item.author?.toLowerCase().includes(currentSearch.toLowerCase())
+      )
+    : viewFiltered;
+
+  const ITEMS_PER_PAGE = 3;
+  const totalItems = searchFiltered.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+  const validPage = Math.min(currentPage, totalPages);
+  const startIndex = (validPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const paginatedContents = searchFiltered.slice(startIndex, endIndex);
+
+  const totalPending = studies.filter((s) => s.isPending).length;
+  const totalProgress = studies.filter((s) => !s.isPending).length;
+  const pendingUntilCurrentPage = studies
+    .filter((p) => p.isPending)
+    .slice(0, currentPage * ITEMS_PER_PAGE).length;
+
+  const progressUntilCurrentPage = studies
+    .filter((p) => !p.isPending)
+    .slice(0, currentPage * ITEMS_PER_PAGE).length;
+
+  return (
+    <>
+      {currentTab === "study" && currentView === "pending" && (
+        <>
+          <div className="mt-4 text-lg text-gray-600">
+            ✔️ 스터디 승인 대기 목록 ({pendingUntilCurrentPage}/{totalPending})
+          </div>
+
+          {paginatedContents.length === 0 ? (
+            <div className="flex items-center justify-center max-h-screen w-full">
+              <DefaultNoneResultUi
+                icon={<TerminalSVG className="text-cert-dark-red" />}
+                title="검색 결과가 없습니다"
+                description="다른 검색어나 필터를 시도해보세요."
+              />
+            </div>
+          ) : (
+            paginatedContents.map((study) => (
+              <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
+                <div key={study.id} className="mt-4 card-list">
+                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                    <div className="flex justify-between items-start">
+                      <div className="space-y-3">
+                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                          <div className="text-xl font-medium">
+                            {study.title}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {study.isPending ? (
+                              <DefaultBadge className="bg-red-100 text-red-800">
+                                승인 대기
+                              </DefaultBadge>
+                            ) : (
+                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                                승인됨
+                              </DefaultBadge>
+                            )}
+                            <DefaultBadge className="bg-green-100 text-green-800">
+                              {study.category}
+                            </DefaultBadge>
+                          </div>
+                        </div>
+                        <div className="text-base text-gray-600">
+                          {study.description}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 본문 */}
+                  <div className="p-6 pt-0">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                      <div className="grid grid-cols-1 md:grid-cols-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <User className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              스터디장: {study.author}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Users className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              최대 인원: {study.maxParticipants}명
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              {study.startDate} ~ {study.endDate}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
+                      {study.attachments?.map((file, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
+                        >
+                          <div className="flex items-center gap-3">
+                            <PdfSVG className="w-5 h-5 text-red-500" />
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {file.name}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {file.size}
+                              </p>
+                            </div>
+                          </div>
+                          <form action={downloadFile}>
+                            <input
+                              type="hidden"
+                              name="fileName"
+                              value={file.name}
+                            />
+                            <input
+                              type="hidden"
+                              name="studyId"
+                              value={study.id}
+                            />
+                            <button type="submit">
+                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                            </button>
+                          </form>
+                        </div>
+                      ))}
+                      <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
+                        <RequestActionButtons
+                          id={study.id}
+                          approveAction={approveRequest}
+                          rejectAction={rejectRequest}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))
+          )}
+        </>
+      )}
+
+      {currentTab === "study" && currentView === "list" && (
+        <>
+          <div className="mt-4 text-lg text-gray-600">
+            📁 스터디 목록 ({progressUntilCurrentPage}/{totalProgress})
+          </div>
+
+          {paginatedContents.length === 0 ? (
+            <div className="flex items-center justify-center max-h-screen w-full">
+              <DefaultNoneResultUi
+                icon={<TerminalSVG className="text-cert-dark-red" />}
+                title="검색 결과가 없습니다"
+                description="다른 검색어나 필터를 시도해보세요."
+              />
+            </div>
+          ) : (
+            paginatedContents.map((study) => (
+              <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
+                <div key={study.id} className="mt-4 card-list">
+                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                    <div className="flex justify-between items-start">
+                      <div className="space-y-3">
+                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                          <div className="text-xl font-medium">
+                            {study.title}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {study.isPending ? (
+                              <DefaultBadge className="bg-red-100 text-red-800">
+                                승인 대기
+                              </DefaultBadge>
+                            ) : (
+                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                                승인됨
+                              </DefaultBadge>
+                            )}
+                            <DefaultBadge className="bg-green-100 text-green-800">
+                              {study.category}
+                            </DefaultBadge>
+                          </div>
+                        </div>
+                        <div className="text-base text-gray-600">
+                          {study.description}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 본문 */}
+                  <div className="p-6 pt-0">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                      <div className="grid grid-cols-1 md:grid-cols-2">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <User className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              스터디장: {study.author}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Users className="w-4 h-4 text-gray-500" />
+                            {isApprovedStudy(study) ? (
+                              <span className="text-sm">
+                                현재 인원: {study.currentParticipants}/
+                                {study.maxParticipants}명
+                              </span>
+                            ) : (
+                              <span className="text-sm">
+                                최대 인원: {study.maxParticipants}명
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="w-4 h-4 text-gray-500" />
+                            <span className="text-sm">
+                              {study.startDate} ~ {study.endDate}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Target className="w-4 h-4 text-gray-500" />
+                            {isApprovedStudy(study) && (
+                              <span className="text-sm">
+                                진행률: {study.progress}%
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="space-y-2 mt-4 ">
+                      {study.attachments?.map((file, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
+                        >
+                          <div className="flex items-center gap-3">
+                            <PdfSVG className="w-5 h-5 text-red-500" />
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {file.name}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {file.size}
+                              </p>
+                            </div>
+                          </div>
+                          <form action={downloadFile}>
+                            <input
+                              type="hidden"
+                              name="fileName"
+                              value={file.name}
+                            />
+                            <input
+                              type="hidden"
+                              name="studyId"
+                              value={study.id}
+                            />
+                            <button type="submit">
+                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                            </button>
+                          </form>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))
+          )}
+        </>
+      )}
+      {totalItems > 0 && (
+        <CCAdminStudyPagination
+          currentPage={validPage}
+          totalPages={totalPages}
+          currentSearch={currentSearch}
+          currentTab={currentTab}
+          currentView={currentView}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/project/CCProjectSearchBar.tsx
+++ b/src/components/project/CCProjectSearchBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import DefaultSearchBar from "@/components/ui/defaultSearchBar";
 import SearchSVG from "/public/icons/search.svg";
 
@@ -16,8 +16,14 @@ export default function ProjectSearchBar({
 }: ProjectSearchBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const [searchInput, setSearchInput] = useState<string>(currentSearch);
   const prevSearchInput = useRef<string>(searchInput);
+
+  const isAdmin = pathname.startsWith("/admin");
+  const placeholder = isAdmin
+    ? "스터디/프로젝트 제목, 설명, 작성자로 검색하세요..."
+    : "프로젝트 제목, 설명, 작성자로 검색하세요...";
 
   useEffect(() => {
     setSearchInput(currentSearch);
@@ -39,18 +45,18 @@ export default function ProjectSearchBar({
       params.delete("page"); // 검색 시 첫 페이지로
 
       const queryString = params.toString();
-      const newUrl = queryString ? `/project?${queryString}` : "/project";
+      const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
       router.push(newUrl, { scroll: false });
     }, DEBOUNCE_DELAY);
 
     return () => clearTimeout(debounceTimer);
-  }, [searchInput, router, searchParams]);
+  }, [searchInput, router, pathname, searchParams]);
 
   return (
     <div className="relative flex-1">
       <SearchSVG className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
       <DefaultSearchBar
-        placeholder="프로젝트 제목, 설명, 작성자로 검색하세요..."
+        placeholder={`${placeholder}`}
         value={searchInput}
         onChange={(e) => setSearchInput(e.target.value)}
         className="pl-10"

--- a/src/components/study/SCStudyContent.tsx
+++ b/src/components/study/SCStudyContent.tsx
@@ -24,6 +24,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
   const studyMaterials: StudyMaterial[] = [
     {
       id: "1",
+      isPending: false,
       title: "OWASP Top 10 2023 취약점 분석",
       description: "최신 OWASP Top 10 취약점에 대한 상세 분석 자료입니다.",
       customTags: [
@@ -56,6 +57,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "2",
+      isPending: false,
       title: "Metasploit Framework 완전 정복",
       description:
         "Metasploit을 활용한 침투 테스트 기법과 실습 자료를 종합적으로 다룹니다.",
@@ -89,6 +91,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "3",
+      isPending: false,
       title: "암호화 기초의 RSA 구현",
       description:
         "암호학의 기초 이론부터 RSA 공개키암호시스템의 Python 구현까지 다룹니다.",
@@ -121,6 +124,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "4",
+      isPending: false,
       title: "디지털 포렌식의 실무 가이드",
       description:
         "Autopsy와 Volatility를 활용한 디지털 증거 수집 및 수집한 분석방법을 설명합니다.",
@@ -154,6 +158,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "5",
+      isPending: false,
       title: "네트워크 보안 모니터링",
       description:
         "Wireshark와 Snort를 활용한 네트워크 트래픽 분석 및 침입 시스템 구축 방법을 다룹니다.",
@@ -187,6 +192,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "6",
+      isPending: false,
       title: "SQL Injection 심화 분석",
       description:
         "다양한 SQL Injection 공격 기법과 방어 전략을 실습과 함께 학습합니다.",
@@ -219,6 +225,7 @@ async function getStudyMaterials(): Promise<StudyMaterial[]> {
     },
     {
       id: "7",
+      isPending: false,
       title: "모바일 앱 보안 테스팅",
       description:
         "Android 및 iOS 앱의 보안 취약점 분석과 테스팅 방법론을 다룹니다.",

--- a/src/layouts/admin/adminNavigationBar.tsx
+++ b/src/layouts/admin/adminNavigationBar.tsx
@@ -9,8 +9,7 @@ import HamburgerMenu from "@/components/nav/hamburgerMenu";
 const navBarList = [
   { name: "Home", href: "/admin" },
   { name: "Schedule", href: "/admin/schedule" },
-  { name: "Study", href: "/admin/study" },
-  { name: "Project", href: "/admin/project" },
+  { name: "Study / Project", href: "/admin/study" },
   { name: "Blog", href: "/admin/blog" },
   { name: "Members", href: "/admin/members" },
 ];

--- a/src/mocks/mockStudyDetailData.ts
+++ b/src/mocks/mockStudyDetailData.ts
@@ -1,4 +1,5 @@
 import { AttachedFile } from "@/types/attachedFile";
+import { StatusType } from "@/types/study";
 
 // 타입 정의
 export interface StudyDetailData {
@@ -19,7 +20,7 @@ export interface StudyDetailData {
   maxParticipants: number;
   currentParticipants: number;
   tags: string[];
-  status: "모집중" | "진행중" | "완료";
+  status: StatusType;
   customTags: { name: string; color: string }[];
   author: string;
   authorStatus: "student" | "graduate";
@@ -77,7 +78,7 @@ export const mockStudyDetailData: StudyDetailData[] = [
     maxParticipants: 10,
     currentParticipants: 7,
     tags: ["웹해킹", "보안", "실습", "OWASP"],
-    status: "진행중",
+    status: "in_progress",
     customTags: [
       { name: "OWASP", color: "bg-blue-100 text-blue-800" },
       { name: "Web Security", color: "bg-purple-100 text-purple-800" },
@@ -178,7 +179,7 @@ export const mockStudyDetailData: StudyDetailData[] = [
     maxParticipants: 10,
     currentParticipants: 10,
     tags: ["침투테스트", "메타스플로잇", "해킹"],
-    status: "완료",
+    status: "completed",
     customTags: [
       { name: "Metasploit", color: "bg-purple-100 text-purple-800" },
       { name: "Penetration Testing", color: "bg-pink-100 text-pink-800" },
@@ -259,7 +260,7 @@ Metasploit Framework는 침투 테스팅과 보안 연구를 위한 강력한 �
     maxParticipants: 10,
     currentParticipants: 1,
     tags: ["암호학", "RSA", "파이썬"],
-    status: "모집중",
+    status: "not_started",
     customTags: [
       { name: "Cryptography", color: "bg-purple-100 text-purple-800" },
       { name: "RSA", color: "bg-green-100 text-green-800" },

--- a/src/types/admin/adminCreateFormData.ts
+++ b/src/types/admin/adminCreateFormData.ts
@@ -1,0 +1,73 @@
+import { AttachedFile } from "@/types/attachedFile";
+
+// study 폼 데이터 타입
+export interface StudyCreateFormData {
+  id: number;
+  isPending: boolean;
+  title: string;
+  description: string;
+  content: string;
+  category: string;
+  tags?: string[];
+  attachments: AttachedFile[];
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  maxParticipants: string;
+  author: string;
+}
+// 외부링크
+export interface ExternalLink {
+  label: string;
+  url: string;
+}
+// project 폼 데이터 타입
+export interface ProjectCreateFormData {
+  id: number;
+  isPending: boolean;
+  title: string;
+  description: string;
+  content: string;
+  category: string;
+  tags: string[];
+  attachments: AttachedFile[];
+  startDate: string;
+  endDate: string;
+  maxParticipants: string;
+  githubUrl?: string;
+  demoUrl?: string;
+  externalLinks: ExternalLink[];
+  projectImage: File | null;
+  author: string;
+}
+
+export type Study =
+  | ({
+      isPending: true;
+      currentParticipants?: never;
+      progress?: never;
+    } & StudyCreateFormData)
+  | ({
+      isPending: false;
+      currentParticipants: number;
+      progress?: number;
+    } & StudyCreateFormData);
+
+export const isApprovedStudy = (
+  s: Study
+): s is Extract<Study, { isPending: false }> => s.isPending === false;
+
+export type Project =
+  | ({
+      isPending: true;
+      currentParticipants?: never;
+      progress?: never;
+    } & ProjectCreateFormData)
+  | ({
+      isPending: false;
+      currentParticipants: number;
+      progress?: number;
+    } & ProjectCreateFormData);
+
+export const isApprovedProject = (
+  p: Project
+): p is Extract<Project, { isPending: false }> => p.isPending === false;

--- a/src/types/admin/adminCreateFormData.ts
+++ b/src/types/admin/adminCreateFormData.ts
@@ -1,6 +1,10 @@
 import { AttachedFile } from "@/types/attachedFile";
 
-// study 폼 데이터 타입
+/**
+ * 스터디 생성 폼에서 사용하는 데이터 타입
+ * - attachments: 첨부파일 목록
+ * - startDate, endDate: YYYY-MM-DD 형식
+ */
 export interface StudyCreateFormData {
   id: number;
   isPending: boolean;
@@ -15,12 +19,16 @@ export interface StudyCreateFormData {
   maxParticipants: string;
   author: string;
 }
-// 외부링크
+/**
+ * 외부 링크 정보
+ */
 export interface ExternalLink {
   label: string;
   url: string;
 }
-// project 폼 데이터 타입
+/**
+ * 프로젝트 생성 폼에서 사용하는 데이터 타입
+ */
 export interface ProjectCreateFormData {
   id: number;
   isPending: boolean;
@@ -40,6 +48,11 @@ export interface ProjectCreateFormData {
   author: string;
 }
 
+/**
+ * 승인 여부에 따라 다른 필드를 가지는 스터디 타입
+ * - 승인 대기: currentParticipants, progress 없음
+ * - 승인 완료: currentParticipants, progress 포함
+ */
 export type Study =
   | ({
       isPending: true;
@@ -52,10 +65,16 @@ export type Study =
       progress?: number;
     } & StudyCreateFormData);
 
+/** 승인 완료된 스터디 판별 함수 */
 export const isApprovedStudy = (
   s: Study
 ): s is Extract<Study, { isPending: false }> => s.isPending === false;
 
+/**
+ * 승인 여부에 따라 다른 필드를 가지는 프로젝트 타입
+ * - 승인 대기: currentParticipants, progress 없음
+ * - 승인 완료: currentParticipants, progress 포함
+ */
 export type Project =
   | ({
       isPending: true;
@@ -68,6 +87,7 @@ export type Project =
       progress?: number;
     } & ProjectCreateFormData);
 
+/** 승인 완료된 프로젝트 판별 함수 */
 export const isApprovedProject = (
   p: Project
 ): p is Extract<Project, { isPending: false }> => p.isPending === false;

--- a/src/types/admin/adminStudyTab.ts
+++ b/src/types/admin/adminStudyTab.ts
@@ -1,0 +1,21 @@
+export const MAIN_TABS = ["study", "project"] as const;
+export type MainTab = (typeof MAIN_TABS)[number];
+
+export const SUB_TABS = ["pending", "list"] as const;
+export type SubTab = (typeof SUB_TABS)[number];
+
+export const TAB_CONFIG: Record<MainTab, { label: string }> = {
+  study: { label: "Study" },
+  project: { label: "Project" },
+};
+
+export const SUBTAB_CONFIG: Record<SubTab, { label: string }> = {
+  pending: { label: "승인 대기" },
+  list: { label: "목록" },
+};
+
+export const isValidMainTab = (t: string): t is MainTab =>
+  MAIN_TABS.includes(t as MainTab);
+
+export const isValidSubTab = (v: string): v is SubTab =>
+  SUB_TABS.includes(v as SubTab);

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -44,6 +44,7 @@ export interface CurrentFilters {
 // Study Material 타입 정의
 export interface StudyMaterial {
   id: string;
+  isPending: boolean;
   title: string;
   description: string;
   customTags: { name: string; color: string }[];

--- a/src/utils/studyHelper.tsx
+++ b/src/utils/studyHelper.tsx
@@ -214,3 +214,12 @@ export function createPageUrl(
   const queryString = params.toString();
   return queryString ? `?${queryString}` : "";
 }
+
+// study D-Day 계산을 위한 함수
+export function calculateDDay(endDate: string): number {
+  const today = new Date();
+  const end = new Date(endDate);
+  const diffTime = end.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #45 

## 📝작업 내용

> - Admin Study/Project 구현했습니다
>     - Tab bar를 통해서 스터디/프로젝트, 승인대기(`isPending === true`)/승인대기 완료(`isPending === false`)된 목록(=진행중인 목록)으로 구분하였습니다
>     - 해당 컨텐츠를 클릭하면 상세페이지로 넘어갈 수 있게 구현했습니다 (쿼리스트링을 사용해서 스터디와 프로젝트 데이터 구분했습니다)
       `http://localhost:3000/admin/study/1?tab=study`, `http://localhost:3000/admin/study/1?tab=project`
>           -> 이 방법이 옳은 방법인지는 모르겠지만.. 지금 생각나는 방법이 이것뿐이네요
>    - 페이지네이션은 나중에 6개로 늘릴 예정입니다 (지금은 mock data가 적어서 2개로 했어요)

### 스크린샷 (선택)

https://github.com/user-attachments/assets/588050e5-206f-471e-967b-a40f97b9e90d

## 💬리뷰 요구사항(선택)

> 도메인을 study로 했는데 괜찮은가요?? 요구명세서에도 스터디/프로젝트(이하 스터디) 로 하셔서 우선은 이렇게 했습니다. 통칭할만한 도메인이 생각이 안나네요
> 피드백 주시면 감사하겠습니다!
