### PR TITLE
Feat, Fix: Admin Page UI 수정 #49

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/page.tsx
@@ -70,7 +70,7 @@ export default async function AdminBlogDetailPage({
         <header className="p-8 border-b border-gray-200">
           {/* 카테고리와 케밥 메뉴 */}
           <div className="flex items-start justify-between mb-4">
-            <div>
+            <div className="flex items-center gap-2">
               <DefaultBadge
                 variant="outline"
                 className={getCategoryColor(post.category)}
@@ -81,7 +81,7 @@ export default async function AdminBlogDetailPage({
               {post.published && (
                 <DefaultBadge
                   variant="outline"
-                  className="bg-gray-200 text-gray-700 border-gray-300 px-3 py-1 text-sm font-medium"
+                  className="bg-gray-200 text-gray-700 border-gray-300"
                 >
                   <ExternalLink className="w-3 h-3 mr-1" />
                   외부 공개

--- a/src/app/(admin)/admin/blog/layout.tsx
+++ b/src/app/(admin)/admin/blog/layout.tsx
@@ -17,7 +17,7 @@ export default function AdminBlogLayout({
       <PageLayout
         title={"Blog"}
         description={"스터디와 프로젝트 결과물을 관리하세요."}
-        icon={<ChatLargeSVG className="stroke-cert-dark-red w-8 h-8" />}
+        icon={<ChatLargeSVG className="stroke-cert-dark-red" />}
       >
         {children}
       </PageLayout>

--- a/src/app/(admin)/admin/blog/page.tsx
+++ b/src/app/(admin)/admin/blog/page.tsx
@@ -10,6 +10,7 @@ import { blogTabCategoryType } from "@/types/admin/adminBlog";
 import { mockBlogPosts } from "@/mocks/blogData";
 import { isValidCategory } from "@/utils/blogUtils";
 import { isValidTab } from "@/utils/adminBlogUtils";
+import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
 
 interface AdminBlogProps {
   searchParams: Promise<{
@@ -82,8 +83,13 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogProps) {
           <CCBlogTabBar />
         </div>
 
-        {/* 포스트 리스트 */}
-        <SCBlogContentList paginatedContents={paginatedContents} />
+        {paginatedContents.length === 0 ? (
+          <div className="flex items-center justify-center max-h-screen w-full">
+            <SCSearchResultNotFound mode="adminBlog" />
+          </div>
+        ) : (
+          <SCBlogContentList paginatedContents={paginatedContents} />
+        )}
 
         {/* 페이지네이션 */}
         {totalItems > 0 && (

--- a/src/app/(admin)/admin/members/page.tsx
+++ b/src/app/(admin)/admin/members/page.tsx
@@ -1,7 +1,7 @@
 "server-only";
 
 import MembersSearchBar from "@/components/members/CCMembersSearchBar";
-import CCMembersList from "@/components/admin/members/CCMembersList";
+import SCMembersContentWrapper from "@/components/admin/members/SCMembersContentWrapper";
 
 interface AdminMembersProps {
   searchParams: Promise<{
@@ -19,7 +19,7 @@ export default async function AdminMembersPage({
     <>
       <MembersSearchBar currentSearch={currentSearch} />
       <div className="flex gap-8 mt-4">
-        <CCMembersList />
+        <SCMembersContentWrapper currentSearch={currentSearch} />
       </div>
     </>
   );

--- a/src/app/(admin)/admin/schedule/page.tsx
+++ b/src/app/(admin)/admin/schedule/page.tsx
@@ -5,6 +5,7 @@ import Calendar from "@/components/schedule/calendar";
 import SCAdminScheduleInfo from "@/components/admin/schedule/SCAdminScheduleInfo";
 import SCAdminScheduleRequestList from "@/components/admin/schedule/SCAdminScheduleRequestList";
 import CCScheduleRequestWrapper from "@/components/schedule/CCScheduleRequestWrapper";
+import CCScrollScheduleList from "@/components/schedule/CCScrollScheduleList";
 
 interface SearchPageProps {
   searchParams: Promise<{ date?: string }>;
@@ -19,6 +20,9 @@ export default async function AdminSchedulePage({
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-7xl mx-auto">
+        <div className="absolute right-4 top-40 sm:hidden z-10">
+          <CCScrollScheduleList />
+        </div>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           <div className="md:col-span-2">
             <Calendar />

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -16,7 +16,7 @@ import MeetingMinutes from "@/components/study/CCMeetingMinutes";
 import EndRequestButton from "@/components/ui/endRequestButton";
 
 interface ProjectDetailPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 const getProjectById = (id: string): ProjectMaterial | undefined => {

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -1,10 +1,7 @@
+"server-only";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import {
-  AUTHOR_STATUS_LABELS,
-  ProjectMaterial,
-  STATUS_LABELS,
-} from "@/types/project";
+import { ProjectMaterial } from "@/types/project";
 import AttachedFilesDownload from "@/components/project/SCAttachedFilesDownload";
 import { Globe, BookText } from "lucide-react";
 import Image from "next/image";
@@ -13,10 +10,13 @@ import BackToListButton from "@/components/detail/SCBackToListButton";
 import KebabMenu from "@/components/detail/CCKebabMenu";
 import ShareButton from "@/components/detail/CCShareButton";
 import { getStatusColor } from "@/utils/projectUtils";
+import { STATUS_LABELS, AUTHOR_STATUS_LABELS } from "@/types/project";
 import DefaultBadge from "@/components/ui/defaultBadge";
+import MeetingMinutes from "@/components/study/CCMeetingMinutes";
+import EndRequestButton from "@/components/ui/endRequestButton";
 
 interface ProjectDetailPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 const getProjectById = (id: string): ProjectMaterial | undefined => {
@@ -91,7 +91,7 @@ export default async function ProjectDetailPage({
   return (
     <div className="mx-auto max-w-full bg-white">
       {/* 뒤로가기 버튼 */}
-      <BackToListButton currentUrl={"admin/study"} />
+      <BackToListButton currentUrl={"admin/study?tab=project"} />
       <article>
         {/* 프로젝트 이미지 */}
         <div className="relative h-96 mb-8 bg-gradient-to-br from-purple-400 to-indigo-600 overflow-hidden mt-6 rounded-lg">
@@ -112,27 +112,17 @@ export default async function ProjectDetailPage({
 
           {/* 상태 배지 */}
           <div className="absolute top-4 left-4">
-            <span
-              className={`px-3 py-1 rounded-full text-xs font-medium backdrop-blur-sm ${getStatusColor(
-                project.status
-              )}`}
+            <DefaultBadge
+              variant="outline"
+              className={getStatusColor(project.status)}
             >
               {STATUS_LABELS[project.status as keyof typeof STATUS_LABELS]}
-            </span>
+            </DefaultBadge>
           </div>
         </div>
 
         {/* 헤더 */}
         <header className=" border-b pb-6">
-          <div className="flex flex-wrap gap-2 mb-4">
-            <DefaultBadge className="bg-gray-100 border border-gray-200 text-gray-700">
-              {project.category}
-            </DefaultBadge>
-            <DefaultBadge className="bg-gray-100 border border-gray-200 text-gray-700">
-              {project.subCategory}
-            </DefaultBadge>
-          </div>
-
           <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl mb-4">
             {project.title}
           </h1>
@@ -192,48 +182,57 @@ export default async function ProjectDetailPage({
         </div>
 
         {/* 액션 버튼들 */}
-        <div className="flex flex-wrap gap-4 mb-8">
-          {project.githubUrl && (
-            <a
-              href={project.githubUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
-            >
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path
-                  fillRule="evenodd"
-                  d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              GitHub 저장소
-            </a>
-          )}
-
-          {project.demoUrl && (
-            <a
-              href={project.demoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+        <div className="flex justify-between items-center gap-4 mb-8">
+          <div className="flex gap-4">
+            {project.githubUrl && (
+              <a
+                href={project.githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                />
-              </svg>
-              데모 사이트
-            </a>
-          )}
+                <svg
+                  className="w-5 h-5"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                GitHub 저장소
+              </a>
+            )}
+
+            {project.demoUrl && (
+              <a
+                href={project.demoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+                데모 사이트
+              </a>
+            )}
+          </div>
+          <span>
+            <EndRequestButton id={project.id} />
+          </span>
         </div>
 
         {/* 첨부파일 섹션 */}
@@ -263,6 +262,11 @@ export default async function ProjectDetailPage({
             <ShareButton></ShareButton>
           </div>
         )}
+        <MeetingMinutes
+          studyId={"1"} // 임시로 ID 설정, 실제로는 params에서 받아와야 함 현재 스터디 ID를 나타내는 ID
+          currentUserId={1} // 임시로 현재 사용자 ID 설정, 실제로는 로그인 정보에서 받아와야 함
+          studyLeaderId={1} // 임시로 스터디 리더 ID 설정, 실제로는 스터디 데이터에서 받아와야 함
+        />
       </article>
     </div>
   );

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -9,12 +9,13 @@ import {
 } from "@/mocks/mockStudyDetailData";
 import BackToListButton from "@/components/detail/SCBackToListButton";
 import KebabMenu from "@/components/detail/CCKebabMenu";
-// import CCShareButton from "@/components/detail/CCShareButton";
 import MeetingMinutes from "@/components/study/CCMeetingMinutes";
 import DownloadButton from "@/components/detail/SCDownloadButton";
 import { formatFileSize } from "@/utils/attachedFileUtils";
 import { getFileIcon } from "@/utils/attachedFileUtils";
 import { calculateDDay, getStatusColor } from "@/utils/studyHelper";
+import { STATUS_LABELS } from "@/types/study";
+import EndRequestButton from "@/components/ui/endRequestButton";
 
 interface StudyDetailPageProps {
   params: { id: string };
@@ -82,7 +83,7 @@ export default async function StudyDetailPage({
                   </h1>
                   <div className="flex items-center gap-2">
                     <DefaultBadge className={getStatusColor(studyData.status)}>
-                      {studyData.status}
+                      {STATUS_LABELS[studyData.status]}
                     </DefaultBadge>
                     {dDay !== null && (
                       <DefaultBadge
@@ -172,6 +173,17 @@ export default async function StudyDetailPage({
                     </div>
                   </div>
                 )}
+
+              <div className="flex justify-between p-1  pt-6 border-t border-gray-300">
+                <div className="flex flex-wrap gap-2 justify-center items-center">
+                  <DefaultBadge className="bg-gray-100 h-6 border border-gray-200 text-gray-700">
+                    {studyData.category}
+                  </DefaultBadge>
+                  <DefaultBadge className="h-6 bg-gray-100 border border-gray-200 text-gray-700">
+                    {studyData.subCategory}
+                  </DefaultBadge>
+                </div>
+              </div>
             </div>
           </div>
           <MeetingMinutes
@@ -259,6 +271,8 @@ export default async function StudyDetailPage({
               </div>
             </div>
           </div>
+          {/* 종료 모달 */}
+          <EndRequestButton id={studyData.id} />
         </div>
       </div>
     </div>

--- a/src/app/(admin)/admin/study/page.tsx
+++ b/src/app/(admin)/admin/study/page.tsx
@@ -1,6 +1,5 @@
 "server-only";
 
-import CCProjectSearchBar from "@/components/project/CCProjectSearchBar";
 import SCStudyContentList from "@/components/admin/study/SCStudyContentList";
 import SCProjectContentList from "@/components/admin/study/SCProjectContentList";
 import CCStudyTabBar from "@/components/admin/study/CCStudyTabBar";
@@ -10,6 +9,9 @@ import {
   MainTab,
   SubTab,
 } from "@/types/admin/adminStudyTab";
+import CCStudyFilter from "@/components/study/CCStudyFilter";
+import { parseSearchParams } from "@/utils/studyHelper";
+import { CurrentFilters } from "@/types/study";
 
 interface AdminStudyProps {
   searchParams: Promise<{
@@ -36,10 +38,11 @@ export default async function AdminStudyPage({
   const currentView: SubTab =
     viewParam && isValidSubTab(viewParam) ? viewParam : "pending";
 
+  const filters: CurrentFilters = parseSearchParams(resolvedSearchParams);
+
   return (
     <div>
-      {/* 서치바는 컴포넌트 하나로 만든 뒤 호출해서 사용하는 게 좋을 것 같아서 따로 브랜치 파서 통일시킬게요 */}
-      <CCProjectSearchBar currentSearch={currentSearch} />
+      <CCStudyFilter currentFilters={filters} isAdmin />
       <CCStudyTabBar currentTab={currentTab} currentView={currentView} />
 
       {currentTab === "study" && (
@@ -48,6 +51,7 @@ export default async function AdminStudyPage({
           currentView={currentView}
           currentSearch={currentSearch}
           currentPage={currentPage}
+          currentFilters={filters}
         />
       )}
 
@@ -57,6 +61,7 @@ export default async function AdminStudyPage({
           currentView={currentView}
           currentSearch={currentSearch}
           currentPage={currentPage}
+          currentFilters={filters}
         />
       )}
     </div>

--- a/src/components/admin/blog/CCPublishedCheckbox.tsx
+++ b/src/components/admin/blog/CCPublishedCheckbox.tsx
@@ -34,7 +34,7 @@ export default function CCPublishedCheckbox({
         type="checkbox"
         checked={isPublished}
         onChange={handleTogglePublic}
-        className="rounded z-20"
+        className="rounded z-10"
       />
       <span className="text-sm">외부 공개</span>
     </label>

--- a/src/components/admin/blog/SCBlogContentList.tsx
+++ b/src/components/admin/blog/SCBlogContentList.tsx
@@ -80,11 +80,14 @@ export default function SCBlogContentList({
                 </p>
               </Link>
 
-              <div className="flex justify-between items-center">
-                <div className="text-sm text-gray-500">
+              <div className="flex justify-between">
+                <Link
+                  href={`/admin/blog/${post.id}`}
+                  className="block flex-1 min-w-0 text-sm text-gray-500"
+                >
                   마지막 수정: {post.createdAt}
-                </div>
-                <div className="flex gap-6">
+                </Link>
+                <div className="shrink-0">
                   <CCPublishedCheckbox
                     postId={post.id}
                     published={post.published}

--- a/src/components/admin/home/SCActivityDashBoard.tsx
+++ b/src/components/admin/home/SCActivityDashBoard.tsx
@@ -28,7 +28,12 @@ const activityDashboardData: ActivityDashboardData = {
 export default function SCActivityDashBoard() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      <Link href={"/admin/study"}>
+      <Link
+        href={{
+          pathname: "/admin/study",
+          query: { tab: "study", view: "list" },
+        }}
+      >
         <div className="card-list text-card-foreground">
           <div className="pb-4 flex flex-col space-y-1.5 p-6">
             <div className="text-lg font-medium leading-none tracking-tight text-gray-600">
@@ -64,7 +69,12 @@ export default function SCActivityDashBoard() {
         </div>
       </Link>
 
-      <Link href={"/admin/project"}>
+      <Link
+        href={{
+          pathname: "/admin/study",
+          query: { tab: "project", view: "list" },
+        }}
+      >
         <div className="card-list text-card-foreground">
           <div className="pb-4 flex flex-col space-y-1.5 p-6">
             <div className="text-lg font-medium leading-none tracking-tight text-gray-600">

--- a/src/components/admin/home/SCPenaltyDashBoard.tsx
+++ b/src/components/admin/home/SCPenaltyDashBoard.tsx
@@ -28,7 +28,7 @@ const withdrawalList = [
 export default function SCPenaltyDashBoard() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      <div className="text-card-foreground card-list cursor-auto">
+      <div className="text-card-foreground card-list cursor-default">
         <div className="pb-4 flex flex-col space-y-1.5 p-6">
           <div className="text-lg font-medium flex text-gray-600 items-center gap-2 leading-none tracking-tight">
             벌점 분포 현황
@@ -44,14 +44,14 @@ export default function SCPenaltyDashBoard() {
         </div>
       </div>
 
-      <div className="text-card-foreground card-list cursor-auto">
+      <div className="text-card-foreground card-list cursor-default">
         <div className="pb-4 flex flex-col space-y-1.5 p-6">
           <div className="flex items-center gap-2 text-lg text-gray-600 font-medium leading-none tracking-tight ">
             <AlertTriangle className="h-5 w-5 text-cert-dark-red" />
             탈퇴 위험 회원
           </div>
           <div className="text-base text-muted-foreground">
-            벌점 2점 이상 회원 목록
+            벌점 4점 이상 회원 목록
           </div>
         </div>
         <div>

--- a/src/components/admin/home/SCSignUpList.tsx
+++ b/src/components/admin/home/SCSignUpList.tsx
@@ -33,7 +33,7 @@ const signUpList: SignUpList[] = [
 
 export default function CCSignUpList() {
   return (
-    <div className="text-card-foreground card-list h-full cursor-auto">
+    <div className="text-card-foreground card-list h-full cursor-default">
       <div className="pb-4 flex flex-col space-y-1.5 p-6">
         <div className="text-lg font-medium flex text-gray-600 items-center gap-2 leading-none tracking-tight">
           <User className="h-5 w-5 text-cert-dark-red" />

--- a/src/components/admin/home/SCTotalDashBoard.tsx
+++ b/src/components/admin/home/SCTotalDashBoard.tsx
@@ -30,7 +30,12 @@ export default function SCTotalDashBoard() {
         </div>
       </Link>
 
-      <Link href={"/admin/study"}>
+      <Link
+        href={{
+          pathname: "/admin/study",
+          query: { tab: "study", view: "list" },
+        }}
+      >
         <div className="text-card-foreground card-list">
           <div className="p-6 flex flex-row items-center justify-between space-y-0 pb-2">
             <div className="text-sm font-medium text-gray-600 leading-none tracking-tight">
@@ -50,7 +55,12 @@ export default function SCTotalDashBoard() {
         </div>
       </Link>
 
-      <Link href={"/admin/project"}>
+      <Link
+        href={{
+          pathname: "/admin/study",
+          query: { tab: "project", view: "list" },
+        }}
+      >
         <div className="text-card-foreground card-list">
           <div className="p-6 flex flex-row items-center justify-between space-y-0 pb-2">
             <div className="text-sm font-medium text-gray-600 leading-none tracking-tight">
@@ -82,7 +92,7 @@ export default function SCTotalDashBoard() {
           </div>
           <div className="p-6 pt-0">
             <div className="text-2xl font-semibold text-cert-dark-red">3명</div>
-            <p className="text-sm text-gray-600 mt-2">벌점 2점 이상 회원</p>
+            <p className="text-sm text-gray-600 mt-2">벌점 4점 이상 회원</p>
           </div>
         </div>
       </Link>

--- a/src/components/admin/members/CCMembersList.tsx
+++ b/src/components/admin/members/CCMembersList.tsx
@@ -1,70 +1,33 @@
 "use client";
 
-import { membersRoleCategories } from "@/types/members";
-import { useSearchParams } from "next/navigation";
 import React, { useState } from "react";
+import { membersRoleCategories } from "@/types/members";
 import { AdminMemberDetailInfoType } from "@/types/admin/adminMembers";
-import { members } from "@/mocks/mockAdminMembersData";
 import CCMembersRow from "@/components/admin/members/CCMembersRow";
 import CCMemberDetailCard from "@/components/admin/members/CCMemberDetailCard";
-import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
-import MembersSVG from "/public/icons/members.svg";
 
-export default function CCMembersList() {
-  const searchParams = useSearchParams();
-  const searchParam = searchParams.get("search") || "";
-  const currentSearch = searchParam;
+interface CCMembersListProps {
+  filteredMembers: AdminMemberDetailInfoType[]; // 서버에서 필터된 결과
+}
+
+export default function CCMembersList({ filteredMembers }: CCMembersListProps) {
   const [selectedMember, setSelectedMember] =
     useState<AdminMemberDetailInfoType | null>(null);
 
-  // 역할별, 이름순 정렬
-  const sortKorean = (a: string, b: string) => a.localeCompare(b, "ko-KR");
-  const sortedMembers = [...(members as AdminMemberDetailInfoType[])].sort(
-    (a, b) => sortKorean(a.name, b.name)
-  );
-
-  const filteredMembers = () => {
-    return sortedMembers.filter(
-      (member: AdminMemberDetailInfoType) =>
-        member.name.includes(currentSearch) ||
-        member.major.includes(currentSearch) ||
-        member.studentId.includes(currentSearch) ||
-        member.currentProjects.some((project: string) =>
-          project.includes(currentSearch)
-        ) ||
-        member.currentStudies.some((study: string) =>
-          study.includes(currentSearch)
-        )
-    );
-  };
-  const filtered = filteredMembers();
-
-  if (filtered.length === 0) {
-    return (
-      <div className="flex items-center justify-center max-h-screen w-full">
-        <DefaultNoneResultUi
-          icon={<MembersSVG className="text-cert-dark-red" />}
-          title="검색 결과가 없습니다"
-          description="다른 검색어나 필터를 시도해보세요."
-        />
-      </div>
-    );
-  }
-
   return (
-    <div className="flex gap-8  w-full">
+    <div className="flex gap-8 w-full">
       {/* 멤버 목록 */}
       <div className="flex-1 rounded-lg border border-gray-200 shadow-sm">
         <div className="px-6 py-4 border-b border-gray-300 flex items-center">
           <h2 className="text-base font-semibold text-gray-800 flex items-center">
             전체 회원
             <span className="text-sm text-gray-500 flex items-center ml-0.5">
-              ({filteredMembers().length}명)
+              ({filteredMembers.length}명)
             </span>
           </h2>
         </div>
         <div className="p-0 overflow-y-auto max-h-[40rem]">
-          <table className="w-full text-sm text text-gray-600">
+          <table className="w-full text-sm text-gray-600">
             <thead className="bg-gray-50 text-left">
               <tr>
                 <th className="px-4 py-2">이름</th>
@@ -76,8 +39,8 @@ export default function CCMembersList() {
             </thead>
             <tbody className="divide-y divide-gray-200">
               {membersRoleCategories.map((role) => {
-                const sorted = filteredMembers().filter(
-                  (member: AdminMemberDetailInfoType) => member.role === role
+                const sorted = filteredMembers.filter(
+                  (member) => member.role === role
                 );
                 if (sorted.length === 0) return null;
 

--- a/src/components/admin/members/SCMembersContentWrapper.tsx
+++ b/src/components/admin/members/SCMembersContentWrapper.tsx
@@ -12,8 +12,6 @@ interface SCMembersContentWrapperProps {
 export default async function SCMembersContentWrapper({
   currentSearch,
 }: SCMembersContentWrapperProps) {
-  const query = (currentSearch ?? "").trim();
-
   const sortKorean = (a: string, b: string) => a.localeCompare(b, "ko-KR");
   const sortedMembers = [...(members as AdminMemberDetailInfoType[])].sort(
     (a, b) => sortKorean(a.name, b.name)

--- a/src/components/admin/members/SCMembersContentWrapper.tsx
+++ b/src/components/admin/members/SCMembersContentWrapper.tsx
@@ -1,0 +1,48 @@
+"server-only";
+
+import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
+import { members } from "@/mocks/mockAdminMembersData";
+import { AdminMemberDetailInfoType } from "@/types/admin/adminMembers";
+import CCMembersList from "@/components/admin/members/CCMembersList";
+
+interface SCMembersContentWrapperProps {
+  currentSearch: string;
+}
+
+export default async function SCMembersContentWrapper({
+  currentSearch,
+}: SCMembersContentWrapperProps) {
+  const query = (currentSearch ?? "").trim();
+
+  const sortKorean = (a: string, b: string) => a.localeCompare(b, "ko-KR");
+  const sortedMembers = [...(members as AdminMemberDetailInfoType[])].sort(
+    (a, b) => sortKorean(a.name, b.name)
+  );
+
+  const filteredMembers = () => {
+    return sortedMembers.filter(
+      (member: AdminMemberDetailInfoType) =>
+        member.name.includes(currentSearch) ||
+        member.major.includes(currentSearch) ||
+        member.studentId.includes(currentSearch) ||
+        member.currentProjects.some((project: string) =>
+          project.includes(currentSearch)
+        ) ||
+        member.currentStudies.some((study: string) =>
+          study.includes(currentSearch)
+        )
+    );
+  };
+  const filtered = filteredMembers();
+
+  if (filtered.length === 0) {
+    return (
+      <div className="flex items-center justify-center max-h-screen w-full">
+        <SCSearchResultNotFound mode="adminMembers" />
+      </div>
+    );
+  }
+
+  // ✅ 데이터만 클라이언트로 내려서 상호작용은 거기서
+  return <CCMembersList filteredMembers={filtered} />;
+}

--- a/src/components/admin/study/CCStudyTabBar.tsx
+++ b/src/components/admin/study/CCStudyTabBar.tsx
@@ -43,7 +43,7 @@ export default function CCStudyTabBar({
             <button
               key={tab}
               onClick={() => handleMainTabClick(tab)}
-              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all
+              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all cursor-pointer
                 ${
                   isActive
                     ? "bg-cert-red text-white shadow-sm"
@@ -63,7 +63,7 @@ export default function CCStudyTabBar({
             <button
               key={view}
               onClick={() => handleSubTabClick(view)}
-              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all
+              className={`inline-flex items-center justify-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-all cursor-pointer
                 ${
                   isActive
                     ? "bg-cert-red text-white shadow-sm"

--- a/src/components/admin/study/SCProjectContentList.tsx
+++ b/src/components/admin/study/SCProjectContentList.tsx
@@ -9,13 +9,12 @@ import {
   rejectRequest,
 } from "@/actions/admin/study/AdminRequestServerAction";
 import { isApprovedProject, Project } from "@/types/admin/adminCreateFormData";
-import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
-import TerminalSVG from "/public/icons/terminal.svg";
 import Link from "next/link";
 import PdfSVG from "/public/icons/pdf.svg";
 import DownloadGraySVG from "/public/icons/download-gray.svg";
 import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
-import CCAdminStudyPagination from "./CCAdminStudyPagination";
+import CCAdminStudyPagination from "@/components/admin/study/CCAdminStudyPagination";
+import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
 
 export const projects: Project[] = [
   // 승인 대기: 폼에서 제출된 필드만 존재
@@ -32,7 +31,8 @@ export const projects: Project[] = [
 
 ## 기술 스택
 - Next.js, TypeScript, TailwindCSS, Supabase`,
-    category: "프론트엔드",
+    category: "CS",
+    subCategory: "논리회로",
     attachments: [
       {
         id: "file_p1_1",
@@ -63,13 +63,14 @@ export const projects: Project[] = [
   {
     id: 2,
     isPending: false,
-    title: "웹 취약점 자동 스캐너 PoC",
+    title: "웹 취약점 자동 필터링 PoC",
     description:
-      "OWASP Top 10 중심 경량 스캐너 PoC. False Positive 최소화에 집중.",
+      "OWASP Top 10 중심 경량 필터링 PoC. False Positive 최소화에 집중.",
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
-    category: "보안",
+    category: "CTF",
+    subCategory: "포너블",
     attachments: [
       {
         id: "file_1_1",
@@ -99,17 +100,18 @@ export const projects: Project[] = [
   {
     id: 3,
     isPending: false,
-    title: "웹 취약점 자동 스캐너 PoC",
+    title: "웹 자동 스캐너 PoC",
     description:
       "OWASP Top 10 중심 경량 스캐너 PoC. False Positive 최소화에 집중.",
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
-    category: "보안",
+    category: "RED",
+    subCategory: "모의해킹",
     attachments: [
       {
         id: "file_1_1",
-        name: "웹 취약점 자동 스캐너 프로젝트_기획서.pdf",
+        name: "웹 자동 스캐너 프로젝트_기획서.pdf",
         size: 2547892,
         type: "application/pdf",
         category: "document",
@@ -141,7 +143,8 @@ export const projects: Project[] = [
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
-    category: "보안",
+    category: "RED",
+    subCategory: "취약점 연구",
     attachments: [
       {
         id: "file_1_1",
@@ -219,6 +222,14 @@ export default function SCProjectContentList({
     .filter((p) => !p.isPending)
     .slice(0, currentPage * ITEMS_PER_PAGE).length;
 
+  if (paginatedContents.length === 0) {
+    return (
+      <div className="flex items-center justify-center max-h-screen w-full">
+        <SCSearchResultNotFound mode="adminProject" />
+      </div>
+    );
+  }
+
   return (
     <>
       {currentTab === "project" && currentView === "pending" && (
@@ -227,128 +238,118 @@ export default function SCProjectContentList({
             ✔️ 프로젝트 승인 대기 목록 ({pendingUntilCurrentPage}/{totalPending}
             )
           </div>
-
-          {paginatedContents.length === 0 ? (
-            <div className="flex items-center justify-center max-h-screen w-full">
-              <DefaultNoneResultUi
-                icon={<TerminalSVG className="text-cert-dark-red" />}
-                title="검색 결과가 없습니다"
-                description="다른 검색어나 필터를 시도해보세요."
-              />
-            </div>
-          ) : (
-            paginatedContents.map((project) => (
-              <Link
-                key={project.id}
-                href={`/admin/study/${project.id}?tab=project`}
-              >
-                <div key={project.id} className="mt-4 card-list">
-                  {/* 헤더 */}
-                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
-                    <div className="flex justify-between items-start">
-                      <div className="space-y-3">
-                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
-                          <div className="text-xl font-medium">
-                            {project.title}
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {project.isPending ? (
-                              <DefaultBadge className="bg-red-100 text-red-800">
-                                승인 대기
-                              </DefaultBadge>
-                            ) : (
-                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
-                                승인됨
-                              </DefaultBadge>
-                            )}
-                            <DefaultBadge className="bg-green-100 text-green-800">
-                              {project.category}
+          {paginatedContents.map((project) => (
+            <Link
+              key={project.id}
+              href={`/admin/study/${project.id}?tab=project`}
+            >
+              <div key={project.id} className="mt-4 card-list">
+                {/* 헤더 */}
+                <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                  <div className="flex justify-between items-start">
+                    <div className="space-y-3">
+                      <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                        <div className="text-xl font-medium">
+                          {project.title}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {project.isPending ? (
+                            <DefaultBadge className="bg-red-100 text-red-800">
+                              승인 대기
                             </DefaultBadge>
-                          </div>
-                        </div>
-                        <div className="text-base text-gray-600">
-                          {project.description}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* 본문 */}
-                  <div className="p-6 pt-0">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
-                      <div className="grid grid-cols-1 md:grid-cols-2">
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <User className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              프로젝트장: {project.author}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Users className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              최대 인원: {project.maxParticipants}명
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <Calendar className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              {project.startDate} ~ {project.endDate}
-                            </span>
-                          </div>
+                          ) : (
+                            <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                              승인됨
+                            </DefaultBadge>
+                          )}
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {project.category}
+                          </DefaultBadge>
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {project.subCategory}
+                          </DefaultBadge>
                         </div>
                       </div>
-                    </div>
-                    <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
-                      {project.attachments?.map((file, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
-                        >
-                          <div className="flex items-center gap-3">
-                            <PdfSVG className="w-5 h-5 text-red-500" />
-                            <div>
-                              <p className="text-sm font-medium text-gray-900">
-                                {file.name}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {file.size}
-                              </p>
-                            </div>
-                          </div>
-                          <form action={downloadFile}>
-                            <input
-                              type="hidden"
-                              name="fileName"
-                              value={file.name}
-                            />
-                            <input
-                              type="hidden"
-                              name="projectId"
-                              value={project.id}
-                            />
-                            <button type="submit">
-                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
-                            </button>
-                          </form>
-                        </div>
-                      ))}
-                      <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
-                        <RequestActionButtons
-                          id={project.id}
-                          approveAction={approveRequest}
-                          rejectAction={rejectRequest}
-                        />
+                      <div className="text-base text-gray-600">
+                        {project.description}
                       </div>
                     </div>
                   </div>
                 </div>
-              </Link>
-            ))
-          )}
+
+                {/* 본문 */}
+                <div className="p-6 pt-0">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                    <div className="grid grid-cols-1 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            프로젝트장: {project.author}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Users className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            최대 인원: {project.maxParticipants}명
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            {project.startDate} ~ {project.endDate}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
+                    {project.attachments?.map((file, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
+                      >
+                        <div className="flex items-center gap-3">
+                          <PdfSVG className="w-5 h-5 text-red-500" />
+                          <div>
+                            <p className="text-sm font-medium text-gray-900">
+                              {file.name}
+                            </p>
+                            <p className="text-xs text-gray-500">{file.size}</p>
+                          </div>
+                        </div>
+                        <form action={downloadFile}>
+                          <input
+                            type="hidden"
+                            name="fileName"
+                            value={file.name}
+                          />
+                          <input
+                            type="hidden"
+                            name="projectId"
+                            value={project.id}
+                          />
+                          <button type="submit">
+                            <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                          </button>
+                        </form>
+                      </div>
+                    ))}
+                    <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
+                      <RequestActionButtons
+                        id={project.id}
+                        approveAction={approveRequest}
+                        rejectAction={rejectRequest}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
         </>
       )}
 
@@ -357,136 +358,126 @@ export default function SCProjectContentList({
           <div className="mt-4 text-lg text-gray-600">
             📁 프로젝트 목록 ({progressUntilCurrentPage}/{totalProgress})
           </div>
-
-          {paginatedContents.length === 0 ? (
-            <div className="flex items-center justify-center max-h-screen w-full">
-              <DefaultNoneResultUi
-                icon={<TerminalSVG className="text-cert-dark-red" />}
-                title="검색 결과가 없습니다"
-                description="다른 검색어나 필터를 시도해보세요."
-              />
-            </div>
-          ) : (
-            paginatedContents.map((project) => (
-              <Link
-                key={project.id}
-                href={`/admin/study/${project.id}?tab=project`}
-              >
-                <div key={project.id} className="mt-4 card-list">
-                  {/* 헤더 */}
-                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
-                    <div className="flex justify-between items-start">
-                      <div className="space-y-3">
-                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
-                          <div className="text-xl font-medium">
-                            {project.title}
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {project.isPending ? (
-                              <DefaultBadge className="bg-red-100 text-red-800">
-                                승인 대기
-                              </DefaultBadge>
-                            ) : (
-                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
-                                승인됨
-                              </DefaultBadge>
-                            )}
-                            <DefaultBadge className="bg-green-100 text-green-800">
-                              {project.category}
+          {paginatedContents.map((project) => (
+            <Link
+              key={project.id}
+              href={`/admin/study/${project.id}?tab=project`}
+            >
+              <div key={project.id} className="mt-4 card-list">
+                {/* 헤더 */}
+                <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                  <div className="flex justify-between items-start">
+                    <div className="space-y-3">
+                      <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                        <div className="text-xl font-medium">
+                          {project.title}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {project.isPending ? (
+                            <DefaultBadge className="bg-red-100 text-red-800">
+                              승인 대기
                             </DefaultBadge>
-                          </div>
-                        </div>
-                        <div className="text-base text-gray-600">
-                          {project.description}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* 본문 */}
-                  <div className="p-6 pt-0">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
-                      <div className="grid grid-cols-1 md:grid-cols-2">
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <User className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              프로젝트장: {project.author}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Users className="w-4 h-4 text-gray-500" />
-                            {isApprovedProject(project) ? (
-                              <span className="text-sm">
-                                현재 인원: {project.currentParticipants}/
-                                {project.maxParticipants}명
-                              </span>
-                            ) : (
-                              <span className="text-sm">
-                                최대 인원: {project.maxParticipants}명
-                              </span>
-                            )}
-                          </div>
-                        </div>
-
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <Calendar className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              {project.startDate} ~ {project.endDate}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Target className="w-4 h-4 text-gray-500" />
-                            {isApprovedProject(project) && (
-                              <span className="text-sm">
-                                진행률: {project.progress}%
-                              </span>
-                            )}
-                          </div>
+                          ) : (
+                            <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                              승인됨
+                            </DefaultBadge>
+                          )}
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {project.category}
+                          </DefaultBadge>
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {project.subCategory}
+                          </DefaultBadge>
                         </div>
                       </div>
-                    </div>
-                    <div className="space-y-2 mt-4 ">
-                      {project.attachments?.map((file, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
-                        >
-                          <div className="flex items-center gap-3">
-                            <PdfSVG className="w-5 h-5 text-red-500" />
-                            <div>
-                              <p className="text-sm font-medium text-gray-900">
-                                {file.name}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {file.size}
-                              </p>
-                            </div>
-                          </div>
-                          <form action={downloadFile}>
-                            <input
-                              type="hidden"
-                              name="fileName"
-                              value={file.name}
-                            />
-                            <input
-                              type="hidden"
-                              name="projectId"
-                              value={project.id}
-                            />
-                            <button type="submit">
-                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
-                            </button>
-                          </form>
-                        </div>
-                      ))}
+                      <div className="text-base text-gray-600">
+                        {project.description}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </Link>
-            ))
-          )}
+
+                {/* 본문 */}
+                <div className="p-6 pt-0">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                    <div className="grid grid-cols-1 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            프로젝트장: {project.author}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Users className="w-4 h-4 text-gray-500" />
+                          {isApprovedProject(project) ? (
+                            <span className="text-sm">
+                              현재 인원: {project.currentParticipants}/
+                              {project.maxParticipants}명
+                            </span>
+                          ) : (
+                            <span className="text-sm">
+                              최대 인원: {project.maxParticipants}명
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            {project.startDate} ~ {project.endDate}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Target className="w-4 h-4 text-gray-500" />
+                          {isApprovedProject(project) && (
+                            <span className="text-sm">
+                              진행률: {project.progress}%
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-2 mt-4 ">
+                    {project.attachments?.map((file, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
+                      >
+                        <div className="flex items-center gap-3">
+                          <PdfSVG className="w-5 h-5 text-red-500" />
+                          <div>
+                            <p className="text-sm font-medium text-gray-900">
+                              {file.name}
+                            </p>
+                            <p className="text-xs text-gray-500">{file.size}</p>
+                          </div>
+                        </div>
+                        <form action={downloadFile}>
+                          <input
+                            type="hidden"
+                            name="fileName"
+                            value={file.name}
+                          />
+                          <input
+                            type="hidden"
+                            name="projectId"
+                            value={project.id}
+                          />
+                          <button type="submit">
+                            <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                          </button>
+                        </form>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
         </>
       )}
       {totalItems > 0 && (

--- a/src/components/admin/study/SCProjectContentList.tsx
+++ b/src/components/admin/study/SCProjectContentList.tsx
@@ -15,6 +15,8 @@ import DownloadGraySVG from "/public/icons/download-gray.svg";
 import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
 import CCAdminStudyPagination from "@/components/admin/study/CCAdminStudyPagination";
 import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
+import { formatFileSize } from "@/utils/attachedFileUtils";
+import { CurrentFilters } from "@/types/project";
 
 export const projects: Project[] = [
   // 승인 대기: 폼에서 제출된 필드만 존재
@@ -31,6 +33,8 @@ export const projects: Project[] = [
 
 ## 기술 스택
 - Next.js, TypeScript, TailwindCSS, Supabase`,
+    semester: "2025-2",
+    status: "not_started",
     category: "CS",
     subCategory: "논리회로",
     attachments: [
@@ -69,6 +73,8 @@ export const projects: Project[] = [
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
+    semester: "2025-2",
+    status: "in_progress",
     category: "CTF",
     subCategory: "포너블",
     attachments: [
@@ -106,6 +112,8 @@ export const projects: Project[] = [
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
+    semester: "2025-2",
+    status: "in_progress",
     category: "RED",
     subCategory: "모의해킹",
     attachments: [
@@ -143,6 +151,8 @@ export const projects: Project[] = [
     content: `### 구성
 - 크롤러 → 검사기 → 리포터
 - 모듈형 규칙 엔진 설계`,
+    semester: "2025-2",
+    status: "in_progress",
     category: "RED",
     subCategory: "취약점 연구",
     attachments: [
@@ -178,6 +188,7 @@ interface SCProjectContentListProps {
   currentView: SubTab;
   currentSearch?: string;
   currentPage?: number;
+  currentFilters: CurrentFilters;
 }
 
 export default function SCProjectContentList({
@@ -185,6 +196,7 @@ export default function SCProjectContentList({
   currentView,
   currentSearch = "",
   currentPage = 1,
+  currentFilters,
 }: SCProjectContentListProps) {
   const viewFiltered =
     currentView === "pending"
@@ -193,24 +205,47 @@ export default function SCProjectContentList({
       ? projects.filter((p) => !p.isPending)
       : projects;
 
-  const searchFiltered = currentSearch
-    ? viewFiltered.filter(
-        (item) =>
-          item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
-          item.description
-            ?.toLowerCase()
-            .includes(currentSearch.toLowerCase()) ||
-          item.author?.toLowerCase().includes(currentSearch.toLowerCase())
-      )
-    : viewFiltered;
+  const filteredProjectMaterials = viewFiltered.filter((item) => {
+    const matchesSearch =
+      !currentSearch ||
+      item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+      item.description?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+      item.author?.toLowerCase().includes(currentSearch.toLowerCase());
+
+    const matchesSemester =
+      currentFilters.semester === "all" ||
+      item.semester === currentFilters.semester;
+
+    const matchesCategory =
+      currentFilters.category === "all" ||
+      item.category === currentFilters.category;
+
+    const matchesSubCategory =
+      currentFilters.subCategory === "all" ||
+      item.subCategory === currentFilters.subCategory;
+
+    const matchesStatus =
+      currentFilters.status === "all" || item.status === currentFilters.status;
+
+    return (
+      matchesSearch &&
+      matchesSemester &&
+      matchesCategory &&
+      matchesSubCategory &&
+      matchesStatus
+    );
+  });
 
   const ITEMS_PER_PAGE = 2;
-  const totalItems = searchFiltered.length;
+  const totalItems = filteredProjectMaterials.length;
   const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
   const validPage = Math.min(currentPage, totalPages);
   const startIndex = (validPage - 1) * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;
-  const paginatedContents = searchFiltered.slice(startIndex, endIndex);
+  const paginatedContents = filteredProjectMaterials.slice(
+    startIndex,
+    endIndex
+  );
 
   const totalPending = projects.filter((p) => p.isPending).length;
   const totalProgress = projects.filter((p) => !p.isPending).length;
@@ -318,7 +353,9 @@ export default function SCProjectContentList({
                             <p className="text-sm font-medium text-gray-900">
                               {file.name}
                             </p>
-                            <p className="text-xs text-gray-500">{file.size}</p>
+                            <p className="text-xs text-gray-500">
+                              {formatFileSize(file.size)}
+                            </p>
                           </div>
                         </div>
                         <form action={downloadFile}>
@@ -453,7 +490,9 @@ export default function SCProjectContentList({
                             <p className="text-sm font-medium text-gray-900">
                               {file.name}
                             </p>
-                            <p className="text-xs text-gray-500">{file.size}</p>
+                            <p className="text-xs text-gray-500">
+                              {formatFileSize(file.size)}
+                            </p>
                           </div>
                         </div>
                         <form action={downloadFile}>

--- a/src/components/admin/study/SCStudyContentList.tsx
+++ b/src/components/admin/study/SCStudyContentList.tsx
@@ -9,13 +9,13 @@ import {
   approveRequest,
   rejectRequest,
 } from "@/actions/admin/study/AdminRequestServerAction";
-import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
-import TerminalSVG from "/public/icons/terminal.svg";
 import Link from "next/link";
 import PdfSVG from "/public/icons/pdf.svg";
 import DownloadGraySVG from "/public/icons/download-gray.svg";
 import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
-import CCAdminStudyPagination from "./CCAdminStudyPagination";
+import CCAdminStudyPagination from "@/components/admin/study/CCAdminStudyPagination";
+import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
+import { CurrentFilters } from "@/types/study";
 
 export const studies: Study[] = [
   {
@@ -24,7 +24,8 @@ export const studies: Study[] = [
     title: "OWASP Top 10 스터디",
     description: "최신 OWASP Top 10을 주차별로 읽고 실습합니다.",
     content: "상세 소개...",
-    category: "보안/웹",
+    category: "CTF",
+    subCategory: "AI",
     attachments: [
       {
         id: "file_1_1",
@@ -48,7 +49,35 @@ export const studies: Study[] = [
     title: "프론트엔드 성능 최적화 스터디",
     description: "렌더링 최적화/번들 분석 등 실무 중심",
     content: "상세 소개...",
-    category: "프론트엔드",
+    category: "CS",
+    subCategory: "정수론",
+    attachments: [
+      {
+        id: "file_1_1",
+        name: "해커톤_기획서.pdf",
+        size: 2547892,
+        type: "application/pdf",
+        category: "document",
+        downloadUrl: "/api/files/download/hackathon_plan.pdf",
+        uploadDate: "2025-01-15T09:30:00Z",
+        description: "해커톤 전체 기획서 및 일정표",
+      },
+    ],
+    startDate: "2025-08-20",
+    endDate: "2025-10-08",
+    maxParticipants: "8",
+    author: "강찬희",
+    currentParticipants: 5,
+    progress: 70,
+  },
+  {
+    id: 3,
+    isPending: false,
+    title: "웹 최적화 스터디",
+    description: "렌더링 최적화/번들 분석 등 실무 중심",
+    content: "상세 소개...",
+    category: "CS",
+    subCategory: "정수론",
     attachments: [
       {
         id: "file_1_1",
@@ -75,6 +104,7 @@ interface SCStudyContentListProps {
   currentView: SubTab;
   currentSearch?: string;
   currentPage: number;
+  currentFilters: CurrentFilters;
 }
 
 export default async function SCStudyContentList({
@@ -82,6 +112,7 @@ export default async function SCStudyContentList({
   currentView,
   currentSearch = "",
   currentPage = 1,
+  currentFilters,
 }: SCStudyContentListProps) {
   const viewFiltered =
     currentView === "pending"
@@ -119,6 +150,14 @@ export default async function SCStudyContentList({
     .filter((p) => !p.isPending)
     .slice(0, currentPage * ITEMS_PER_PAGE).length;
 
+  if (paginatedContents.length === 0) {
+    return (
+      <div className="flex items-center justify-center max-h-screen w-full">
+        <SCSearchResultNotFound mode="adminStudy" />
+      </div>
+    );
+  }
+
   return (
     <>
       {currentTab === "study" && currentView === "pending" && (
@@ -127,123 +166,112 @@ export default async function SCStudyContentList({
             ✔️ 스터디 승인 대기 목록 ({pendingUntilCurrentPage}/{totalPending})
           </div>
 
-          {paginatedContents.length === 0 ? (
-            <div className="flex items-center justify-center max-h-screen w-full">
-              <DefaultNoneResultUi
-                icon={<TerminalSVG className="text-cert-dark-red" />}
-                title="검색 결과가 없습니다"
-                description="다른 검색어나 필터를 시도해보세요."
-              />
-            </div>
-          ) : (
-            paginatedContents.map((study) => (
-              <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
-                <div key={study.id} className="mt-4 card-list">
-                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
-                    <div className="flex justify-between items-start">
-                      <div className="space-y-3">
-                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
-                          <div className="text-xl font-medium">
-                            {study.title}
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {study.isPending ? (
-                              <DefaultBadge className="bg-red-100 text-red-800">
-                                승인 대기
-                              </DefaultBadge>
-                            ) : (
-                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
-                                승인됨
-                              </DefaultBadge>
-                            )}
-                            <DefaultBadge className="bg-green-100 text-green-800">
-                              {study.category}
+          {paginatedContents.map((study) => (
+            <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
+              <div key={study.id} className="mt-4 card-list">
+                <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                  <div className="flex justify-between items-start">
+                    <div className="space-y-3">
+                      <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                        <div className="text-xl font-medium">{study.title}</div>
+                        <div className="flex items-center gap-2">
+                          {study.isPending ? (
+                            <DefaultBadge className="bg-red-100 text-red-800">
+                              승인 대기
                             </DefaultBadge>
-                          </div>
-                        </div>
-                        <div className="text-base text-gray-600">
-                          {study.description}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* 본문 */}
-                  <div className="p-6 pt-0">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
-                      <div className="grid grid-cols-1 md:grid-cols-2">
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <User className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              스터디장: {study.author}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Users className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              최대 인원: {study.maxParticipants}명
-                            </span>
-                          </div>
-                        </div>
-
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <Calendar className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              {study.startDate} ~ {study.endDate}
-                            </span>
-                          </div>
+                          ) : (
+                            <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                              승인됨
+                            </DefaultBadge>
+                          )}
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {study.category}
+                          </DefaultBadge>
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {study.subCategory}
+                          </DefaultBadge>
                         </div>
                       </div>
-                    </div>
-                    <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
-                      {study.attachments?.map((file, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
-                        >
-                          <div className="flex items-center gap-3">
-                            <PdfSVG className="w-5 h-5 text-red-500" />
-                            <div>
-                              <p className="text-sm font-medium text-gray-900">
-                                {file.name}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {file.size}
-                              </p>
-                            </div>
-                          </div>
-                          <form action={downloadFile}>
-                            <input
-                              type="hidden"
-                              name="fileName"
-                              value={file.name}
-                            />
-                            <input
-                              type="hidden"
-                              name="studyId"
-                              value={study.id}
-                            />
-                            <button type="submit">
-                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
-                            </button>
-                          </form>
-                        </div>
-                      ))}
-                      <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
-                        <RequestActionButtons
-                          id={study.id}
-                          approveAction={approveRequest}
-                          rejectAction={rejectRequest}
-                        />
+                      <div className="text-base text-gray-600">
+                        {study.description}
                       </div>
                     </div>
                   </div>
                 </div>
-              </Link>
-            ))
-          )}
+
+                {/* 본문 */}
+                <div className="p-6 pt-0">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                    <div className="grid grid-cols-1 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            스터디장: {study.author}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Users className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            최대 인원: {study.maxParticipants}명
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            {study.startDate} ~ {study.endDate}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-0 mt-4 flex justify-between flex-col md:flex-row gap-5">
+                    {study.attachments?.map((file, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between bg-gray-50 rounded-lg p-3 w-full sm:w-[35rem]"
+                      >
+                        <div className="flex items-center gap-3">
+                          <PdfSVG className="w-5 h-5 text-red-500" />
+                          <div>
+                            <p className="text-sm font-medium text-gray-900">
+                              {file.name}
+                            </p>
+                            <p className="text-xs text-gray-500">{file.size}</p>
+                          </div>
+                        </div>
+                        <form action={downloadFile}>
+                          <input
+                            type="hidden"
+                            name="fileName"
+                            value={file.name}
+                          />
+                          <input
+                            type="hidden"
+                            name="studyId"
+                            value={study.id}
+                          />
+                          <button type="submit">
+                            <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                          </button>
+                        </form>
+                      </div>
+                    ))}
+                    <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
+                      <RequestActionButtons
+                        id={study.id}
+                        approveAction={approveRequest}
+                        rejectAction={rejectRequest}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
         </>
       )}
 
@@ -253,131 +281,120 @@ export default async function SCStudyContentList({
             📁 스터디 목록 ({progressUntilCurrentPage}/{totalProgress})
           </div>
 
-          {paginatedContents.length === 0 ? (
-            <div className="flex items-center justify-center max-h-screen w-full">
-              <DefaultNoneResultUi
-                icon={<TerminalSVG className="text-cert-dark-red" />}
-                title="검색 결과가 없습니다"
-                description="다른 검색어나 필터를 시도해보세요."
-              />
-            </div>
-          ) : (
-            paginatedContents.map((study) => (
-              <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
-                <div key={study.id} className="mt-4 card-list">
-                  <div className="pb-4 flex flex-col space-y-1.5 p-6">
-                    <div className="flex justify-between items-start">
-                      <div className="space-y-3">
-                        <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
-                          <div className="text-xl font-medium">
-                            {study.title}
-                          </div>
-                          <div className="flex items-center gap-2">
-                            {study.isPending ? (
-                              <DefaultBadge className="bg-red-100 text-red-800">
-                                승인 대기
-                              </DefaultBadge>
-                            ) : (
-                              <DefaultBadge className="bg-yellow-100 text-yellow-800">
-                                승인됨
-                              </DefaultBadge>
-                            )}
-                            <DefaultBadge className="bg-green-100 text-green-800">
-                              {study.category}
+          {paginatedContents.map((study) => (
+            <Link key={study.id} href={`/admin/study/${study.id}?tab=study`}>
+              <div key={study.id} className="mt-4 card-list">
+                <div className="pb-4 flex flex-col space-y-1.5 p-6">
+                  <div className="flex justify-between items-start">
+                    <div className="space-y-3">
+                      <div className="flex gap-3 sm:flex-row sm:items-center flex-col items-start">
+                        <div className="text-xl font-medium">{study.title}</div>
+                        <div className="flex items-center gap-2">
+                          {study.isPending ? (
+                            <DefaultBadge className="bg-red-100 text-red-800">
+                              승인 대기
                             </DefaultBadge>
-                          </div>
-                        </div>
-                        <div className="text-base text-gray-600">
-                          {study.description}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* 본문 */}
-                  <div className="p-6 pt-0">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
-                      <div className="grid grid-cols-1 md:grid-cols-2">
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <User className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              스터디장: {study.author}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Users className="w-4 h-4 text-gray-500" />
-                            {isApprovedStudy(study) ? (
-                              <span className="text-sm">
-                                현재 인원: {study.currentParticipants}/
-                                {study.maxParticipants}명
-                              </span>
-                            ) : (
-                              <span className="text-sm">
-                                최대 인원: {study.maxParticipants}명
-                              </span>
-                            )}
-                          </div>
-                        </div>
-
-                        <div className="space-y-1">
-                          <div className="flex items-center gap-2">
-                            <Calendar className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">
-                              {study.startDate} ~ {study.endDate}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Target className="w-4 h-4 text-gray-500" />
-                            {isApprovedStudy(study) && (
-                              <span className="text-sm">
-                                진행률: {study.progress}%
-                              </span>
-                            )}
-                          </div>
+                          ) : (
+                            <DefaultBadge className="bg-yellow-100 text-yellow-800">
+                              승인됨
+                            </DefaultBadge>
+                          )}
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {study.category}
+                          </DefaultBadge>
+                          <DefaultBadge className="bg-green-100 text-green-800">
+                            {study.subCategory}
+                          </DefaultBadge>
                         </div>
                       </div>
-                    </div>
-                    <div className="space-y-2 mt-4 ">
-                      {study.attachments?.map((file, index) => (
-                        <div
-                          key={index}
-                          className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
-                        >
-                          <div className="flex items-center gap-3">
-                            <PdfSVG className="w-5 h-5 text-red-500" />
-                            <div>
-                              <p className="text-sm font-medium text-gray-900">
-                                {file.name}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {file.size}
-                              </p>
-                            </div>
-                          </div>
-                          <form action={downloadFile}>
-                            <input
-                              type="hidden"
-                              name="fileName"
-                              value={file.name}
-                            />
-                            <input
-                              type="hidden"
-                              name="studyId"
-                              value={study.id}
-                            />
-                            <button type="submit">
-                              <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
-                            </button>
-                          </form>
-                        </div>
-                      ))}
+                      <div className="text-base text-gray-600">
+                        {study.description}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </Link>
-            ))
-          )}
+
+                {/* 본문 */}
+                <div className="p-6 pt-0">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-stretch">
+                    <div className="grid grid-cols-1 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            스터디장: {study.author}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Users className="w-4 h-4 text-gray-500" />
+                          {isApprovedStudy(study) ? (
+                            <span className="text-sm">
+                              현재 인원: {study.currentParticipants}/
+                              {study.maxParticipants}명
+                            </span>
+                          ) : (
+                            <span className="text-sm">
+                              최대 인원: {study.maxParticipants}명
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4 text-gray-500" />
+                          <span className="text-sm">
+                            {study.startDate} ~ {study.endDate}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Target className="w-4 h-4 text-gray-500" />
+                          {isApprovedStudy(study) && (
+                            <span className="text-sm">
+                              진행률: {study.progress}%
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-2 mt-4 ">
+                    {study.attachments?.map((file, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between bg-gray-50 rounded-lg p-3"
+                      >
+                        <div className="flex items-center gap-3">
+                          <PdfSVG className="w-5 h-5 text-red-500" />
+                          <div>
+                            <p className="text-sm font-medium text-gray-900">
+                              {file.name}
+                            </p>
+                            <p className="text-xs text-gray-500">{file.size}</p>
+                          </div>
+                        </div>
+                        <form action={downloadFile}>
+                          <input
+                            type="hidden"
+                            name="fileName"
+                            value={file.name}
+                          />
+                          <input
+                            type="hidden"
+                            name="studyId"
+                            value={study.id}
+                          />
+                          <button type="submit">
+                            <DownloadGraySVG className="text-gray-400 hover:text-gray-600" />
+                          </button>
+                        </form>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
         </>
       )}
       {totalItems > 0 && (

--- a/src/components/admin/study/SCStudyContentList.tsx
+++ b/src/components/admin/study/SCStudyContentList.tsx
@@ -15,6 +15,7 @@ import DownloadGraySVG from "/public/icons/download-gray.svg";
 import { downloadFile } from "@/actions/study/StudyDownloadFileServerAction";
 import CCAdminStudyPagination from "@/components/admin/study/CCAdminStudyPagination";
 import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
+import { formatFileSize } from "@/utils/attachedFileUtils";
 import { CurrentFilters } from "@/types/study";
 
 export const studies: Study[] = [
@@ -24,6 +25,7 @@ export const studies: Study[] = [
     title: "OWASP Top 10 스터디",
     description: "최신 OWASP Top 10을 주차별로 읽고 실습합니다.",
     content: "상세 소개...",
+    semester: "2025-2",
     category: "CTF",
     subCategory: "AI",
     attachments: [
@@ -42,6 +44,7 @@ export const studies: Study[] = [
     endDate: "2025-11-30",
     maxParticipants: "12",
     author: "김보안",
+    status: "not_started",
   },
   {
     id: 2,
@@ -49,6 +52,7 @@ export const studies: Study[] = [
     title: "프론트엔드 성능 최적화 스터디",
     description: "렌더링 최적화/번들 분석 등 실무 중심",
     content: "상세 소개...",
+    semester: "2025-2",
     category: "CS",
     subCategory: "정수론",
     attachments: [
@@ -69,6 +73,7 @@ export const studies: Study[] = [
     author: "강찬희",
     currentParticipants: 5,
     progress: 70,
+    status: "in_progress",
   },
   {
     id: 3,
@@ -76,8 +81,9 @@ export const studies: Study[] = [
     title: "웹 최적화 스터디",
     description: "렌더링 최적화/번들 분석 등 실무 중심",
     content: "상세 소개...",
+    semester: "2025-2",
     category: "CS",
-    subCategory: "정수론",
+    subCategory: "선형대수학",
     attachments: [
       {
         id: "file_1_1",
@@ -96,6 +102,7 @@ export const studies: Study[] = [
     author: "강찬희",
     currentParticipants: 5,
     progress: 70,
+    status: "in_progress",
   },
 ];
 
@@ -121,24 +128,45 @@ export default async function SCStudyContentList({
       ? studies.filter((s) => !s.isPending)
       : studies;
 
-  const searchFiltered = currentSearch
-    ? viewFiltered.filter(
-        (item) =>
-          item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
-          item.description
-            ?.toLowerCase()
-            .includes(currentSearch.toLowerCase()) ||
-          item.author?.toLowerCase().includes(currentSearch.toLowerCase())
-      )
-    : viewFiltered;
+  const filteredStudyMaterials = viewFiltered.filter((item) => {
+    const matchesSearch =
+      !currentSearch ||
+      item.title?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+      item.description?.toLowerCase().includes(currentSearch.toLowerCase()) ||
+      item.author?.toLowerCase().includes(currentSearch.toLowerCase());
 
+    const matchesSemester =
+      currentFilters.semester === "all" ||
+      item.semester === currentFilters.semester;
+
+    const matchesCategory =
+      currentFilters.category === "all" ||
+      item.category === currentFilters.category;
+
+    const matchesSubCategory =
+      currentFilters.subCategory === "all" ||
+      item.subCategory === currentFilters.subCategory;
+
+    const matchesStatus =
+      currentFilters.status === "all" || item.status === currentFilters.status;
+
+    return (
+      matchesSearch &&
+      matchesSemester &&
+      matchesCategory &&
+      matchesSubCategory &&
+      matchesStatus
+    );
+  });
+
+  // 🔹 페이지네이션
   const ITEMS_PER_PAGE = 3;
-  const totalItems = searchFiltered.length;
+  const totalItems = filteredStudyMaterials.length;
   const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
   const validPage = Math.min(currentPage, totalPages);
   const startIndex = (validPage - 1) * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;
-  const paginatedContents = searchFiltered.slice(startIndex, endIndex);
+  const paginatedContents = filteredStudyMaterials.slice(startIndex, endIndex);
 
   const totalPending = studies.filter((s) => s.isPending).length;
   const totalProgress = studies.filter((s) => !s.isPending).length;
@@ -240,7 +268,9 @@ export default async function SCStudyContentList({
                             <p className="text-sm font-medium text-gray-900">
                               {file.name}
                             </p>
-                            <p className="text-xs text-gray-500">{file.size}</p>
+                            <p className="text-xs text-gray-500">
+                              {formatFileSize(file.size)}
+                            </p>
                           </div>
                         </div>
                         <form action={downloadFile}>

--- a/src/components/admin/study/SCStudyContentList.tsx
+++ b/src/components/admin/study/SCStudyContentList.tsx
@@ -290,7 +290,7 @@ export default async function SCStudyContentList({
                         </form>
                       </div>
                     ))}
-                    <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-end">
+                    <div className="flex flex-row gap-2 w-full sm:w-[20rem] h-full justify-end items-end self-end justify-self-en">
                       <RequestActionButtons
                         id={study.id}
                         approveAction={approveRequest}

--- a/src/components/members/SCMembersCardList.tsx
+++ b/src/components/members/SCMembersCardList.tsx
@@ -1,7 +1,6 @@
-import MembersSVG from "/public/icons/members.svg";
-import SCMembersCard from "./SCMembersCard";
-import DefaultNoneResultUi from "@/components/ui/defaultNoneResultUi";
+import SCMembersCard from "@/components/members/SCMembersCard";
 import { MembersDataType } from "@/types/members";
+import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
 
 interface MembersCardListProps {
   members: MembersDataType[];
@@ -9,13 +8,7 @@ interface MembersCardListProps {
 
 export default function MembersCardList({ members }: MembersCardListProps) {
   if (members.length === 0) {
-    return (
-      <DefaultNoneResultUi
-        icon={<MembersSVG className="text-cert-dark-red" />}
-        title="검색 결과가 없습니다"
-        description="다른 검색어나 필터를 시도해보세요."
-      />
-    );
+    return <SCSearchResultNotFound mode="members" />;
   }
 
   return (

--- a/src/components/nav/hamburgerMenu.tsx
+++ b/src/components/nav/hamburgerMenu.tsx
@@ -44,6 +44,14 @@ export default function HamburgerMenu({ navBarList }: HamburgerMenuProps) {
     }
   }, [pathname, handleClose]); // handleClose를 의존성 배열에 추가
 
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "auto";
+    }
+  }, [isOpen]);
+
   return (
     <>
       <div className="flex md:hidden relative z-10">

--- a/src/components/nav/navBarItems.tsx
+++ b/src/components/nav/navBarItems.tsx
@@ -24,7 +24,7 @@ const NavBarItems = ({ navBarList }: NavBarItemsProps) => {
           <Link
             key={item.name}
             href={item.href}
-            className={`px-4 py-2 text-sm mx-0.5 transition-all duration-300 rounded-lg relative group overflow-hidden
+            className={`px-4 py-2 text-sm mx-0.5 transition-all duration-300 rounded-lg relative group
               ${
                 isActive
                   ? "text-cert-dark-red bg-cert-dark-red/5 shadow-cert-navbar"

--- a/src/components/profile/SCPenaltyStatus.tsx
+++ b/src/components/profile/SCPenaltyStatus.tsx
@@ -8,7 +8,7 @@ export default function SCPenaltyStatus() {
 
   return (
     <div className="mt-7">
-      <div className="card-list text-card-foreground text-center group p-6 cursor-auto">
+      <div className="card-list text-card-foreground text-center group p-6 cursor-default">
         <h3 className="text-xl font-semibold mb-6 text-gray-900 flex items-center gap-2 ">
           <WarningSVG className="w-5 h-5 text-cert-red" />
           벌점
@@ -31,7 +31,7 @@ export default function SCPenaltyStatus() {
           ].map((stat, index) => (
             <div
               key={index}
-              className="card-list text-card-foreground text-center group cursor-auto"
+              className="card-list text-card-foreground text-center group cursor-default"
             >
               <div className="flex flex-col space-y-1.5 p-4">
                 <div className="leading-none tracking-tight text-2xl font-bold text-cert-red transition-transform duration-300">

--- a/src/components/profile/SCStudyList.tsx
+++ b/src/components/profile/SCStudyList.tsx
@@ -83,7 +83,7 @@ export default async function SCStudyList({ searchParams }: SCStudyListProps) {
                       <div className="flex items-center gap-4 mt-2 text-sm text-gray-600 transition-colors duration-300">
                         <span>{material.startDate}</span>
                         <DefaultBadge
-                          className={`border-gray-200 text-gray-600 cursor-default
+                          className={`border-gray-200 text-gray-600 cursor-auto
                           ${getStudyCategoryColor(
                             material.tab as StudyTabType
                           )}`}

--- a/src/components/profile/SCTodaySchedule.tsx
+++ b/src/components/profile/SCTodaySchedule.tsx
@@ -16,7 +16,7 @@ const todaySchedule = mockScheduleData.filter(
 export default function SCTodaySchedule() {
   return (
     <div className="mt-7">
-      <div className="card-list text-card-foreground p-6 cursor-auto">
+      <div className="card-list text-card-foreground p-6 cursor-default">
         <h3 className="text-xl font-semibold mb-6 text-gray-900 flex items-center gap-2">
           <ScheduleSVG className="w-5 h-5 stroke-cert-red" />
           오늘 일정
@@ -27,7 +27,7 @@ export default function SCTodaySchedule() {
               {todaySchedule.map((schedule) => (
                 <div
                   key={schedule.id}
-                  className="card-list bg-gray-50 flex items-center justify-between p-3 group cursor-auto"
+                  className="card-list bg-gray-50 flex items-center justify-between p-3 group cursor-default"
                 >
                   <div>
                     <div className="font-medium text-sm text-gray-900 dark:text-gray-100 group-hover:text-red-600 dark:group-hover:text-red-400 transition-colors">

--- a/src/components/project/CCProjectFilter.tsx
+++ b/src/components/project/CCProjectFilter.tsx
@@ -10,6 +10,7 @@ import {
   STATUS_OPTIONS,
   SEMESTER_LABELS,
   STATUS_LABELS,
+  FilterKey,
 } from "@/types/project";
 import DefaultButton from "@/components/ui/defaultButton";
 import { cn } from "@/lib/utils";
@@ -46,7 +47,7 @@ export default function CCProjectFilter({
   const statusRef = useRef<HTMLDivElement>(null);
 
   const updateFilter = useCallback(
-    (key: string, value: string) => {
+    (key: FilterKey, value: string) => {
       const params = new URLSearchParams(searchParams.toString());
 
       if (value === "all" || value === "") {

--- a/src/components/project/CCProjectFilter.tsx
+++ b/src/components/project/CCProjectFilter.tsx
@@ -163,7 +163,7 @@ export default function CCProjectFilter({
               </span>
               <ChevronDown
                 className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
-                  showSemesterDropdown ? "rotate-180" : ""
+                  showCategoryDropdown ? "rotate-180" : ""
                 }`}
               />
             </DefaultButton>

--- a/src/components/schedule/SCScheduleList.tsx
+++ b/src/components/schedule/SCScheduleList.tsx
@@ -48,7 +48,7 @@ export default async function SCScheduleList({
           {filteredSchedules.map((schedule) => (
             <div
               key={schedule.id}
-              className="card-list text-card-foreground bg-white rounded-xl border shadow-sm"
+              className="card-list text-card-foreground bg-white rounded-xl border shadow-sm cursor-default"
             >
               <div className="flex flex-col space-y-1.5 p-6">
                 <div className="flex items-start justify-between">

--- a/src/components/study/SCStudyContent.tsx
+++ b/src/components/study/SCStudyContent.tsx
@@ -19,6 +19,7 @@ import PdfSVG from "/public/icons/pdf.svg";
 import Link from "next/link";
 import DefaultBadge from "@/components/ui/defaultBadge";
 import { getCategoryColor } from "@/utils/categoryColorUtils";
+import { formatFileSize } from "@/utils/attachedFileUtils";
 
 // 학습 자료 데이터를 가져오는 함수 (실제로는 DB에서 가져올 것)
 async function getStudyMaterials(): Promise<StudyMaterial[]> {
@@ -417,7 +418,9 @@ export default async function SCStudyContent({
                             <p className="text-sm font-medium text-gray-900">
                               {file.name}
                             </p>
-                            <p className="text-xs text-gray-500">{file.size}</p>
+                            <p className="text-xs text-gray-500">
+                              {formatFileSize(file.size)}
+                            </p>
                           </div>
                         </div>
                         <form action={downloadFile}>

--- a/src/components/ui/SCSearchResultNotFound.tsx
+++ b/src/components/ui/SCSearchResultNotFound.tsx
@@ -7,7 +7,17 @@ interface SCSearchResultNotFoundProps {
   description?: string;
   icon?: React.ReactNode;
   showResetButton?: boolean;
-  mode?: "study" | "project" | "blog" | "board";
+  mode?:
+    | "board"
+    | "study"
+    | "project"
+    | "blog"
+    | "members"
+    | "adminBoard"
+    | "adminStudy"
+    | "adminProject"
+    | "adminBlog"
+    | "adminMembers";
 }
 
 export default async function SCSearchResultNotFound({
@@ -36,10 +46,16 @@ export default async function SCSearchResultNotFound({
 
   // mode -> pathname 매핑
   const pathByMode = {
+    board: "/board",
     study: "/study",
     project: "/project",
     blog: "/blog",
-    board: "/board",
+    members: "/members",
+    adminBoard: "/admin/board",
+    adminStudy: "/admin/study?tab=study",
+    adminProject: "/admin/study?tab=project",
+    adminBlog: "/admin/blog",
+    adminMembers: "/admin/members",
   } as const;
 
   // ✅ bind로 pathname을 고정한 서버 액션 생성

--- a/src/components/ui/defaultNoneResultUi.tsx
+++ b/src/components/ui/defaultNoneResultUi.tsx
@@ -1,3 +1,4 @@
+"server-only";
 interface DefaultNoneResultUiProps {
   icon: React.ReactNode;
   title: string;

--- a/src/components/ui/endRequestButton.tsx
+++ b/src/components/ui/endRequestButton.tsx
@@ -4,14 +4,24 @@ import { useState } from "react";
 import DefaultButton from "@/components/ui/defaultButton";
 import ConfirmModal from "@/components/ui/defaultConfirmModal";
 import type { AttachedFile } from "@/types/attachedFile";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 export default function EndRequestButton({ id }: { id: number | string }) {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const pathname = usePathname();
-  const pageType = pathname.startsWith("/study") ? "스터디" : "프로젝트";
+  const searchParams = useSearchParams();
+
+  const tab = (searchParams.get("tab") || "").toLowerCase();
+  const pageType: "study" | "project" =
+    tab === "study" || tab === "project"
+      ? (tab as "study" | "project")
+      : pathname.startsWith("/admin/study")
+      ? "study"
+      : "project";
+
+  const pageLabel = pageType === "study" ? "스터디" : "프로젝트";
 
   const openModal = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -43,16 +53,16 @@ export default function EndRequestButton({ id }: { id: number | string }) {
       <DefaultButton
         onClick={openModal}
         disabled={submitting}
-        className="px-6 py-2 w-full bg-white text-cert-red hover:text-white hover:bg-cert-red dark:bg-gray-800 rounded-lg shadow-lg border border-cert-red/50 dark:border-gray-700  cursor-pointer"
+        className="px-6 py-2 w-full bg-white text-cert-red hover:text-white hover:bg-cert-red dark:bg-gray-800 rounded-lg shadow-lg border border-cert-red/50 dark:border-gray-700 cursor-pointer"
       >
-        {pageType} 종료하기
+        {pageLabel} 종료하기
       </DefaultButton>
 
       <ConfirmModal
         isOpen={isOpenModal}
         type="endConfirm"
-        title={`${pageType} 종료하기`}
-        message={`${pageType}의 결과물과 구글폼 링크를 제출해주세요.`}
+        title={`${pageLabel} 종료하기`}
+        message={`${pageLabel}의 결과물과 구글폼 링크를 제출해주세요.`}
         confirmText={submitting ? "제출 중..." : "제출"}
         cancelText="취소"
         onConfirm={handleEndRequest}

--- a/src/mocks/blogData.ts
+++ b/src/mocks/blogData.ts
@@ -36,7 +36,7 @@ setTimeout(() => {
     views: 1250,
     likes: 45,
     featured: true,
-    published: true,
+    published: false,
   },
   {
     id: 2,

--- a/src/types/admin/adminCreateFormData.ts
+++ b/src/types/admin/adminCreateFormData.ts
@@ -1,4 +1,5 @@
 import { AttachedFile } from "@/types/attachedFile";
+import { CategoryType, SubCategoryType } from "@/types/category";
 
 /**
  * 스터디 생성 폼에서 사용하는 데이터 타입
@@ -11,7 +12,8 @@ export interface StudyCreateFormData {
   title: string;
   description: string;
   content: string;
-  category: string;
+  category: CategoryType;
+  subCategory: SubCategoryType;
   attachments: AttachedFile[];
   startDate: string; // YYYY-MM-DD
   endDate: string; // YYYY-MM-DD
@@ -34,7 +36,8 @@ export interface ProjectCreateFormData {
   title: string;
   description: string;
   content: string;
-  category: string;
+  category: CategoryType;
+  subCategory: SubCategoryType;
   attachments: AttachedFile[];
   startDate: string;
   endDate: string;

--- a/src/types/admin/adminCreateFormData.ts
+++ b/src/types/admin/adminCreateFormData.ts
@@ -1,5 +1,6 @@
 import { AttachedFile } from "@/types/attachedFile";
 import { CategoryType, SubCategoryType } from "@/types/category";
+import { StatusType } from "@/types/study";
 
 /**
  * 스터디 생성 폼에서 사용하는 데이터 타입
@@ -12,6 +13,8 @@ export interface StudyCreateFormData {
   title: string;
   description: string;
   content: string;
+  semester: string;
+  status: StatusType;
   category: CategoryType;
   subCategory: SubCategoryType;
   attachments: AttachedFile[];
@@ -36,6 +39,8 @@ export interface ProjectCreateFormData {
   title: string;
   description: string;
   content: string;
+  semester: string;
+  status: StatusType;
   category: CategoryType;
   subCategory: SubCategoryType;
   attachments: AttachedFile[];


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #49 

## 📝작업 내용

> ### Home
> - 벌점 4점 이상으로 수정
> - /admin/project 없으므로 /admin/study 수정
> - search not found 통일 (members는 CC로 구현되어서 wrapper로 감싸서 에러 해결했습니다.)
> <img width="600"  alt="스크린샷 2025-08-21 02 13 38" src="https://github.com/user-attachments/assets/8fdfbfd5-5149-4c1a-acc4-77943118726c" />


> ### Study / Project 
> - 세부페이지는 서비스페이지 UI와 통일
> - 카테고리 드롭다운 추가
> - 현재는 한 페이지 당 2개 씩만 보이도록 구현 (페이지네이션 확인 위해)
> - search input을 ‘X’ 버튼 누르면 초기화되게끔 수정

https://github.com/user-attachments/assets/aa4f64a9-deba-47a3-836e-192133caad42




### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> UI적으로 괜찮은지 확인 부탁드립니다!
