### PR TITLE
Feat, Fix: TOP 버튼 및 Blog WriteForm 내 스터디/프로젝트 선택 기능 추가, UI 수정 #59

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/page.tsx
@@ -8,6 +8,7 @@ import ShareButton from "@/components/detail/CCShareButton";
 import DefaultBadge from "@/components/ui/defaultBadge";
 import { formatDate } from "@/utils/formatDateUtil";
 import { getCategoryColor } from "@/utils/categoryColorUtils";
+import Link from "next/link";
 
 interface BlogDetailPageProps {
   params: Promise<{
@@ -90,19 +91,32 @@ export default async function AdminBlogDetailPage({
             </div>
             <KebabMenuButton currentUrl={"blog"} currentId={blogId} />
           </div>
-
           {/* 제목 */}
           <h1 className="text-3xl font-bold text-gray-900 mb-4 leading-tight">
             {post.title}
           </h1>
-
           {/* 요약 */}
           {post.excerpt && (
-            <p className="text-lg text-gray-600 mb-6 leading-relaxed">
+            <p className="text-lg text-gray-600 mb-3 leading-relaxed">
               {post.excerpt}
             </p>
           )}
-
+          {post.reference && (
+            <div className="mb-3">
+              <Link
+                href={`/${post.reference.type}/${post.reference.referenceId}`}
+                className={`inline-flex items-center px-3 py-1 text-sm font-medium rounded-md transition-colors
+        ${
+          post.reference.type === "study"
+            ? "text-green-700 bg-green-50 border border-green-200 hover:bg-green-100 hover:text-green-800"
+            : "text-blue-700 bg-blue-50 border border-blue-200 hover:bg-blue-100 hover:text-blue-800"
+        }`}
+              >
+                {post.reference.type === "study" ? "스터디" : "프로젝트"} ·{" "}
+                {post.reference.title}
+              </Link>
+            </div>
+          )}
           {/* 메타 정보 */}
           <div className="flex flex-wrap items-center gap-6 text-sm text-gray-600">
             <div className="flex items-center gap-2">

--- a/src/app/(main)/blog/[id]/page.tsx
+++ b/src/app/(main)/blog/[id]/page.tsx
@@ -9,6 +9,7 @@ import { formatDate } from "@/utils/formatDateUtil";
 import { getCategoryColor } from "@/utils/categoryColorUtils";
 import DefaultBadge from "@/components/ui/defaultBadge";
 import CCPublishedCheckbox from "@/components/admin/blog/CCPublishedCheckbox";
+import Link from "next/link";
 
 interface BlogDetailPageProps {
   params: Promise<{
@@ -85,10 +86,27 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
           </h1>
           {/* 요약 */}
           {post.excerpt && (
-            <p className="text-lg text-gray-600 mb-6 leading-relaxed">
+            <p className="text-lg text-gray-600 mb-3 leading-relaxed">
               {post.excerpt}
             </p>
           )}
+          {post.reference && (
+            <div className="mb-3">
+              <Link
+                href={`/${post.reference.type}/${post.reference.referenceId}`}
+                className={`inline-flex items-center px-3 py-1 text-sm font-medium rounded-md transition-colors
+        ${
+          post.reference.type === "study"
+            ? "text-green-700 bg-green-50 border border-green-200 hover:bg-green-100 hover:text-green-800"
+            : "text-blue-700 bg-blue-50 border border-blue-200 hover:bg-blue-100 hover:text-blue-800"
+        }`}
+              >
+                {post.reference.type === "study" ? "스터디" : "프로젝트"} ·{" "}
+                {post.reference.title}
+              </Link>
+            </div>
+          )}
+
           {/* 메타 정보 */}
           <div className="flex flex-wrap items-center text-sm text-gray-600 justify-between">
             <div className="flex flex-row gap-6">

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -133,10 +133,21 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
                   </h3>
 
                   {/* 내용 미리보기 */}
-                  <p className="text-gray-600 text-sm mb-4 line-clamp-3 leading-relaxed">
+                  <p className="text-gray-600 text-sm mb-2 line-clamp-3 leading-relaxed">
                     {post.excerpt}
                   </p>
-
+                  {post.reference && (
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium mb-3 ${
+                        post.reference.type === "study"
+                          ? "text-green-700 bg-green-50 border border-green-200"
+                          : "text-blue-700 bg-blue-50 border border-blue-200"
+                      }`}
+                    >
+                      {post.reference.type === "study" ? "스터디" : "프로젝트"}{" "}
+                      · {post.reference.title}
+                    </span>
+                  )}
                   {/* 작성자 */}
                   <div className="flex items-center gap-2 pt-2 border-t border-gray-100">
                     <div className="w-7 h-7 bg-gray-200 rounded-full flex items-center justify-center">
@@ -147,6 +158,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
                     <span className="text-sm text-gray-700 font-medium">
                       {post.author}
                     </span>
+                    {/* ✅ reference 뱃지 */}
                   </div>
                 </div>
               </Link>

--- a/src/app/(main)/board/[id]/page.tsx
+++ b/src/app/(main)/board/[id]/page.tsx
@@ -80,7 +80,9 @@ export default async function DetailPage({
         <div className="p-6 pb-0">
           <div className="flex items-start justify-between mb-4">
             <div className="flex items-center gap-3">
-              {data.isNotice && <Pin className="w-4 h-4 text-cert-red" />}
+              {data.category === "공지사항" && (
+                <Pin className="w-4 h-4 text-cert-red" />
+              )}
               <DefaultBadge
                 variant="outline"
                 className={getCategoryColor(data.category)}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,3 +1,4 @@
+import CCTopButton from "@/components/ui/CCTopButton";
 import Footer from "@/layouts/footer";
 import NavigationBar from "@/layouts/navigationBar";
 
@@ -12,9 +13,12 @@ export default function MainLayout({
         <NavigationBar />
       </header>
       <main className="flex-1">{children}</main>
+
       <footer>
         <Footer />
       </footer>
+      {/* ✅ Top 버튼은 페이지 어디서든 표시 */}
+      <CCTopButton />
     </div>
   );
 }

--- a/src/components/admin/blog/SCBlogContentList.tsx
+++ b/src/components/admin/blog/SCBlogContentList.tsx
@@ -1,7 +1,7 @@
 "server-only";
 
 import DefaultBadge from "@/components/ui/defaultBadge";
-import { ExternalLink, Eye, FileText } from "lucide-react";
+import { ExternalLink, Eye, FileText, BookOpen, Code } from "lucide-react";
 import Link from "next/link";
 import CCBlogDeleteButton from "@/components/admin/blog/CCBlogDeleteButton";
 import CCPublishedCheckbox from "@/components/admin/blog/CCPublishedCheckbox";
@@ -31,6 +31,7 @@ export default function SCBlogContentList({
                     {post.title}
                   </span>
 
+                  {/* 카테고리 뱃지 */}
                   <DefaultBadge
                     variant="outline"
                     className={getCategoryColor(post.category)}
@@ -38,6 +39,26 @@ export default function SCBlogContentList({
                     {post.category}
                   </DefaultBadge>
 
+                  {post.reference && (
+                    <DefaultBadge
+                      variant="outline"
+                      className={`flex items-center gap-1 ${
+                        post.reference.type === "study"
+                          ? "text-green-700 bg-green-50 border-green-200"
+                          : "text-blue-700 bg-blue-50 border-blue-200"
+                      }`}
+                    >
+                      {post.reference.type === "study" ? (
+                        <BookOpen className="w-3 h-3" />
+                      ) : (
+                        <Code className="w-3 h-3" />
+                      )}
+                      {post.reference.type === "study" ? "스터디" : "프로젝트"}{" "}
+                      · {post.reference.title}
+                    </DefaultBadge>
+                  )}
+
+                  {/* 외부 공개 뱃지 */}
                   {post.published && (
                     <DefaultBadge
                       variant="outline"
@@ -87,6 +108,7 @@ export default function SCBlogContentList({
                 >
                   마지막 수정: {post.createdAt}
                 </Link>
+
                 <div className="shrink-0">
                   <CCPublishedCheckbox
                     postId={post.id}

--- a/src/components/admin/members/CCMemberEditModal.tsx
+++ b/src/components/admin/members/CCMemberEditModal.tsx
@@ -144,7 +144,7 @@ export default function CCRoleEditModal({
                           closeAllDropdowns();
                         }}
                       >
-                        {option.label}학년
+                        {option.label}
                       </button>
                     ))}
                   </div>

--- a/src/components/auth/signup/CCSignUpForm.tsx
+++ b/src/components/auth/signup/CCSignUpForm.tsx
@@ -68,7 +68,7 @@ export default function CCSignUpForm() {
             type="text"
             value={signupFormData.name}
             onChange={handleInputChange}
-            className={`input-default pl-10 pl-10 ${
+            className={`input-default pl-10 ${
               errors.name ? "border-red-500" : ""
             }`}
             placeholder="홍길동"

--- a/src/components/board/SCBoardCard.tsx
+++ b/src/components/board/SCBoardCard.tsx
@@ -1,53 +1,59 @@
 import Link from "next/link";
-import ThunderSVG from "/public/icons/thunder.svg";
 import EyeSVG from "/public/icons/eye.svg";
-import InfoSVG from "/public/icons/info.svg";
-import AlertTriangleSVG from "/public/icons/alert-triangle.svg";
 import DefaultBadge from "@/components/ui/defaultBadge";
-import { BoardPriorityType } from "@/types/board";
 import { BoardDataType } from "@/types/board";
 import { getCategoryColor } from "@/utils/boardUtils";
-import { Heart } from "lucide-react";
+import {
+  AlertCircle,
+  BookOpen,
+  Heart,
+  HelpCircle,
+  Info,
+  ShieldAlert,
+} from "lucide-react";
 
-// svg 요소가 있어 util로 빼기 애매함
-const getPriorityIcon = (priority: BoardPriorityType) => {
-  switch (priority) {
-    case "high":
-      return <AlertTriangleSVG />;
-    case "medium":
-      return <InfoSVG />;
-    default:
-      return <ThunderSVG className="text-cert-accent w-4 h-4" />;
+// 카테고리 종류에 따라 svg 변경 uitl
+const getCategoryIcon = (category: string) => {
+  switch (category) {
+    case "공지사항":
+      return <AlertCircle className="text-red-700 w-4 h-4" />;
+    case "보안이슈":
+      return <ShieldAlert className="text-orange-700 w-4 h-4" />;
+    case "기술자료":
+      return <BookOpen className="text-blue-700 w-4 h-4" />;
+    case "활동내용":
+      return <Info className="text-green-700 w-4 h-4" />;
+    case "질문":
+      return <HelpCircle className="text-gray-700 w-4 h-4" />;
   }
 };
-
 export default function BoardCard({
   id,
   title,
   content,
   author,
   category,
-  priority,
   date,
   views,
   likes,
-  isNotice,
 }: BoardDataType) {
   return (
     <Link href={`/board/${id}`}>
       <div
         className={`card-list group hover:border-cert-red/50  ${
-          isNotice ? "border-red-200 bg-red-50" : "border-gray-200"
+          category === "공지사항"
+            ? "border-red-200 bg-red-50"
+            : "border-gray-200"
         }`}
       >
         <div className="flex flex-col space-y-1.5 p-6 pb-3">
           <div className="flex items-center gap-3 flex-1 justify-between">
             <div className="flex items-center gap-2">
-              {getPriorityIcon(priority)}
+              {getCategoryIcon(category)}
               <DefaultBadge className={getCategoryColor(category)}>
                 {category}
               </DefaultBadge>
-              {isNotice && (
+              {category === "공지사항" && (
                 <DefaultBadge className="bg-cert-red text-white">
                   공지
                 </DefaultBadge>

--- a/src/components/members/SCMembersCard.tsx
+++ b/src/components/members/SCMembersCard.tsx
@@ -51,7 +51,7 @@ export default function MembersCard({ members }: MembersCardProps) {
 
           <div className="mt-2 text-sm text-gray-500">
             <p>
-              {members.grade}학년 • {members.major}
+              {members.grade} • {members.major}
             </p>
           </div>
         </div>

--- a/src/components/profile/CCProfileEditModal.tsx
+++ b/src/components/profile/CCProfileEditModal.tsx
@@ -387,7 +387,7 @@ export default function CCProfileModal({
                 {editedUser.name}
               </div>
               <div className="text-xs text-center text-gray-600">
-                {editedUser.grade ? `${editedUser.grade}학년 · ` : ""}
+                {editedUser.grade ? `${editedUser.grade} · ` : ""}
                 {editedUser.major}
               </div>
               <div className="text-xs text-center text-gray-600 mt-1">

--- a/src/components/profile/SCBlogList.tsx
+++ b/src/components/profile/SCBlogList.tsx
@@ -33,35 +33,53 @@ export default async function SCBlogList({
             <h3 className="text-lg font-semibold text-gray-900 transition-colors duration-300">
               내가 작성한 블로그 포스트
             </h3>
-            <Link href="/blog">
+            <Link href="/blog/write">
               <DefaultButton size="sm" className="transition-all duration-300">
                 <Plus className="w-4 h-4" />새 포스트 작성
               </DefaultButton>
             </Link>
           </div>
-
           {blogs.map((blog) => (
             <Link href={`/blog/${blog.id}`} key={blog.id}>
               <div className="card-list text-card-foreground group mb-4">
                 <div className="flex flex-col space-y-1.5 p-6">
                   <div className="flex items-start justify-between">
                     <div>
+                      {/* 제목 */}
                       <div className="font-semibold leading-none tracking-tight text-lg text-gray-900 group-hover:text-red-600 transition-colors cursor-pointer">
                         {blog.title}
                       </div>
-                      <div className="flex items-center gap-4 mt-2 text-sm text-gray-600 transition-colors duration-300">
+
+                      {/* 작성일 + 카테고리 + ✅ reference */}
+                      <div className="flex items-center gap-2 mt-2 text-sm text-gray-600 transition-colors duration-300">
                         <span>{blog.createdAt}</span>
                         <DefaultBadge
-                          className={`border-gray-200 text-gray-600 ${getCategoryColor(
+                          className={`border-gray-200 text-gray-600 ml-2 ${getCategoryColor(
                             blog.category as BlogCategory
                           )}`}
                         >
                           {blog.category}
                         </DefaultBadge>
+
+                        {blog.reference && (
+                          <span
+                            className={`ml-auto rounded-full inline-flex items-center px-2 py-0.5 text-xs font-medium ${
+                              blog.reference.type === "study"
+                                ? "text-green-700 bg-green-50 border border-green-200"
+                                : "text-blue-700 bg-blue-50 border border-blue-200"
+                            }`}
+                          >
+                            {blog.reference.type === "study"
+                              ? "스터디"
+                              : "프로젝트"}{" "}
+                            · {blog.reference.title}
+                          </span>
+                        )}
                       </div>
                     </div>
                   </div>
                 </div>
+
                 <div className="p-6 pt-0">
                   <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400 transition-colors duration-300">
                     <div className="flex items-center gap-1">

--- a/src/components/profile/SCBlogList.tsx
+++ b/src/components/profile/SCBlogList.tsx
@@ -3,7 +3,6 @@
 import DefaultButton from "@/components/ui/defaultButton";
 import DefaultBadge from "@/components/ui/defaultBadge";
 import EyeSVG from "/public/icons/eye.svg";
-import ThumbsUpSVG from "/public/icons/thumbs-up.svg";
 import { ProfileBlogDataType } from "@/types/profile";
 import Link from "next/link";
 import { Plus } from "lucide-react";
@@ -68,10 +67,6 @@ export default async function SCBlogList({
                     <div className="flex items-center gap-1">
                       <EyeSVG className="w-4 h-4" />
                       {blog.views}
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <ThumbsUpSVG />
-                      {blog.likes}
                     </div>
                   </div>
                 </div>

--- a/src/components/profile/SCPenaltyStatus.tsx
+++ b/src/components/profile/SCPenaltyStatus.tsx
@@ -23,9 +23,9 @@ export default function SCPenaltyStatus() {
             {
               title: "벌점 유예 기간",
               value:
-                profile.role === "PLAYER"
-                  ? "-"
-                  : "D - " + profile.penaltyPeriod,
+                profile.role === "UPSOLVER"
+                  ? "D - " + +profile.penaltyPeriod
+                  : "-",
               color: "red-600",
             },
           ].map((stat, index) => (

--- a/src/components/profile/SCProfileCard.tsx
+++ b/src/components/profile/SCProfileCard.tsx
@@ -42,7 +42,7 @@ export default function SCProfileCard() {
               variant="outline"
               className="border-gray-200  text-gray-600 "
             >
-              {user.grade}학년
+              {user.grade}
             </DefaultBadge>
           </div>
           <div className="text-sm text-gray-600  transition-colors duration-300">

--- a/src/components/study/CCMeetingMinutes.tsx
+++ b/src/components/study/CCMeetingMinutes.tsx
@@ -180,7 +180,8 @@ export default function MeetingMinutes({
       participants: 0,
       links: [],
     });
-    setShowAddModal(false);
+    // setShowAddModal(false);
+    closeModal();
   };
 
   const handleEditMinute = (minute: MeetingMinute) => {
@@ -454,8 +455,9 @@ export default function MeetingMinutes({
                   회의록 내용
                 </label>
                 <p className="text-xs text-gray-500 mb-2">
-                  해당 회의록은 회의내용을 간추려 5줄이내로 적어주시기 바랍니다.
-                  만약 관련 지식이나 내용이 있다면 블로그를 활용해주세요.
+                  해당 회의록은 회의 내용을 간추려 5줄 이내로 적어주시기
+                  바랍니다. 만약 관련 지식이나 내용이 있다면 블로그를
+                  활용해주세요.
                 </p>
                 <textarea
                   value={newMinute.content}

--- a/src/components/study/CCMeetingMinutes.tsx
+++ b/src/components/study/CCMeetingMinutes.tsx
@@ -77,6 +77,7 @@ export default function MeetingMinutes({
   const [newMinute, setNewMinute] = useState({
     title: "",
     content: "",
+    participants: 0,
     links: [] as LinkItem[],
   });
   const [deleteMinuteId, setDeleteMinuteId] = useState<number | null>(null);
@@ -166,16 +167,17 @@ export default function MeetingMinutes({
       title: newMinute.title,
       content: newMinute.content,
       links: validLinks,
-      author: "현재 사용자",
+      author: "현재 사용자", // TODO: 실제 사용자 이름으로 변경
       created_at: formatDate(new Date(), "dot"),
       updated_at: formatDate(new Date(), "dot"),
-      participants: 0,
+      participants: newMinute.participants,
     };
 
     setMeetingMinutes([...meetingMinutes, minute]);
     setNewMinute({
       title: "",
       content: "",
+      participants: 0,
       links: [],
     });
     setShowAddModal(false);
@@ -186,6 +188,7 @@ export default function MeetingMinutes({
     setNewMinute({
       title: minute.title,
       content: minute.content,
+      participants: minute.participants,
       links: minute.links || [],
     });
     openModal();
@@ -205,6 +208,7 @@ export default function MeetingMinutes({
             ...minute,
             title: newMinute.title,
             content: newMinute.content,
+            participants: newMinute.participants,
             links: validLinks,
           }
         : minute
@@ -212,7 +216,7 @@ export default function MeetingMinutes({
 
     setMeetingMinutes(updated);
     setEditingMinute(null);
-    setNewMinute({ title: "", content: "", links: [] });
+    setNewMinute({ title: "", content: "", participants: 0, links: [] });
     setShowAddModal(false);
   };
 
@@ -397,7 +401,12 @@ export default function MeetingMinutes({
                 onClick={() => {
                   closeModal();
                   setEditingMinute(null);
-                  setNewMinute({ title: "", content: "", links: [] });
+                  setNewMinute({
+                    title: "",
+                    content: "",
+                    participants: 0,
+                    links: [],
+                  });
                 }}
                 className="text-gray-400 hover:text-gray-600"
               >
@@ -422,7 +431,27 @@ export default function MeetingMinutes({
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
-                  회의록 링크
+                  참석 인원
+                </label>
+                <input
+                  type="number"
+                  value={
+                    newMinute.participants === 0 ? "" : newMinute.participants
+                  }
+                  onChange={(e) =>
+                    setNewMinute({
+                      ...newMinute,
+                      participants:
+                        e.target.value === "" ? 0 : Number(e.target.value),
+                    })
+                  }
+                  placeholder="참석 인원 수를 입력하세요 (숫자만 입력)"
+                  className="text-sm w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-cert-red focus:border-transparent"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  회의록 내용
                 </label>
                 <p className="text-xs text-gray-500 mb-2">
                   해당 회의록은 회의내용을 간추려 5줄이내로 적어주시기 바랍니다.
@@ -491,7 +520,7 @@ export default function MeetingMinutes({
 
                   {newMinute.links.length === 0 && (
                     <p className="text-sm text-gray-500 italic">
-                      링크를 추가하려면 &quot;링크 추가&quot; 버튼을 클릭하세요.
+                      회의록 링크를 추가해주세요.
                     </p>
                   )}
                 </div>
@@ -503,7 +532,12 @@ export default function MeetingMinutes({
                   onClick={() => {
                     closeModal();
                     setEditingMinute(null);
-                    setNewMinute({ title: "", content: "", links: [] });
+                    setNewMinute({
+                      title: "",
+                      content: "",
+                      participants: 0,
+                      links: [],
+                    });
                   }}
                   className="flex-1"
                 >
@@ -512,7 +546,9 @@ export default function MeetingMinutes({
                 <DefaultButton
                   onClick={editingMinute ? handleUpdateMinute : handleAddMinute}
                   disabled={
-                    !newMinute.title.trim() || !newMinute.content.trim()
+                    !newMinute.title.trim() ||
+                    !newMinute.participants ||
+                    !newMinute.content.trim()
                   }
                   className="flex-1"
                 >

--- a/src/components/ui/CCTopButton.tsx
+++ b/src/components/ui/CCTopButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ArrowUp } from "lucide-react";
+
+export default function CCTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 100); // 300px 이상 스크롤하면 버튼 표시
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-white border border-cert-red/40 text-cert-red/70 shadow-lg hover:bg-cert-red/20 transition-colors"
+    >
+      <ArrowUp className="w-5 h-5" />
+    </button>
+  );
+}

--- a/src/components/write/CCEditForm.tsx
+++ b/src/components/write/CCEditForm.tsx
@@ -304,7 +304,11 @@ export default function EditForm({ type, dataId }: EditFormProps) {
           <div className="relative">
             <button
               type="button"
-              onClick={() => setIsSelecteReferenceOpen((prev) => !prev)}
+              onClick={() => {
+                setIsSelecteReferenceOpen((prev) => !prev);
+                setIsCategoryOpen(false);
+                setIsSubCategoryOpen(false);
+              }}
               className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm cursor-pointer"
             >
               <span
@@ -336,7 +340,7 @@ export default function EditForm({ type, dataId }: EditFormProps) {
                         setSelectedReference(reference);
                         setIsSelecteReferenceOpen(false);
                       }}
-                      className="w-full px-2 py-2 text-sm text-left hover:bg-cert-red hover:text-white cursor-pointer"
+                      className="relative flex w-full cursor-pointer select-none items-center rounded-sm py-2 px-2 text-sm outline-none transition-colors hover:bg-cert-red hover:text-white focus:bg-cert-red focus:text-white"
                     >
                       {reference.type === "study" ? "스터디" : "프로젝트"} -{" "}
                       {reference.title}

--- a/src/components/write/CCWriteForm.tsx
+++ b/src/components/write/CCWriteForm.tsx
@@ -14,6 +14,7 @@ import {
   getSubCategories,
 } from "@/utils/newPageFormUtils";
 import { AttachedFile } from "@/types/attachedFile";
+import { Reference } from "@/types/blog";
 
 interface WriteFormProps {
   type: NewPageCategoryType;
@@ -25,6 +26,25 @@ const PLAN_SAMPLE = {
   href: "/samples/plan-sample.docx", // public/samples/plan-sample.docx 에 파일 두기
 };
 
+// 내가 참여한 활동 리스트 (더미 예시)
+const myActivities: Reference[] = [
+  { referenceId: 1, type: "study", title: "OWASP Top 10 2023 취약점 분석" },
+  {
+    referenceId: 2,
+    type: "study",
+    title: "Metasploit Framework 완전 정복",
+  },
+  {
+    referenceId: 1,
+    type: "project",
+    title: "Social Impact Hackathon 2025",
+  },
+  {
+    referenceId: 2,
+    type: "project",
+    title: "OWASP Top 10 2023 취약점 분석",
+  },
+];
 export default function WriteForm({ type }: WriteFormProps) {
   const router = useRouter();
   const [title, setTitle] = useState<string>("");
@@ -38,8 +58,15 @@ export default function WriteForm({ type }: WriteFormProps) {
   const [maxParticipants, setMaxParticipants] = useState("");
   const [isCategoryOpen, setIsCategoryOpen] = useState<boolean>(false);
   const [isSubCategoryOpen, setIsSubCategoryOpen] = useState<boolean>(false);
+  const [isSelectedReferenceOpen, setIsSelecteReferenceOpen] =
+    useState<boolean>(false);
+  const [selectedReference, setSelectedReference] = useState<Reference | null>(
+    null
+  );
+
   const categoryRef = useRef<HTMLDivElement>(null);
   const subCategoryRef = useRef<HTMLDivElement>(null);
+  const selectedReferenceRef = useRef<HTMLDivElement>(null);
 
   // 프로젝트 전용 필드들
   const [githubUrl, setGithubUrl] = useState<string>("");
@@ -54,6 +81,7 @@ export default function WriteForm({ type }: WriteFormProps) {
   const closeAllDropdowns = useCallback(() => {
     setIsCategoryOpen(false);
     setIsSubCategoryOpen(false);
+    setIsSelecteReferenceOpen(false);
   }, []);
 
   // 외부 클릭 감지
@@ -62,7 +90,8 @@ export default function WriteForm({ type }: WriteFormProps) {
       const target = e.target as Node;
       if (
         categoryRef.current?.contains(target) ||
-        subCategoryRef.current?.contains(target)
+        subCategoryRef.current?.contains(target) ||
+        selectedReferenceRef.current?.contains(target)
       ) {
         return;
       }
@@ -98,6 +127,7 @@ export default function WriteForm({ type }: WriteFormProps) {
       content,
       category,
       attachments,
+      ...(type === "blog" ? { activity: selectedReference } : {}),
       ...(type === "study" || type === "project" ? { startDate, endDate } : {}),
       ...(type === "study" || type === "project" ? { maxParticipants } : {}),
       ...(type === "project"
@@ -183,6 +213,68 @@ export default function WriteForm({ type }: WriteFormProps) {
           선택사항이지만, 다른 사용자들이 내용을 빠르게 파악할 수 있도록
           도와줍니다.
         </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div
+          className={`relative ${
+            type === "blog" || type === "board" ? "md:col-span-3" : ""
+          }`}
+          ref={selectedReferenceRef}
+        >
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            내가 참여한 스터디 / 프로젝트 목록 *
+          </label>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setIsSelecteReferenceOpen((prev) => !prev)}
+              className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm cursor-pointer"
+            >
+              <span
+                className={
+                  selectedReference ? "text-gray-900" : "text-gray-500"
+                }
+              >
+                {selectedReference
+                  ? `${
+                      selectedReference.type === "study" ? "스터디" : "프로젝트"
+                    } - ${selectedReference.title}`
+                  : "활동 선택"}
+              </span>
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${
+                  isSelectedReferenceOpen ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+
+            {isSelectedReferenceOpen && (
+              <div className="absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                <div className="max-h-60 overflow-auto p-1">
+                  {myActivities.map((reference) => (
+                    <button
+                      key={`${reference.type}-${reference.referenceId}`}
+                      type="button"
+                      onClick={() => {
+                        setSelectedReference(reference);
+                        setIsSelecteReferenceOpen(false);
+                      }}
+                      className="w-full px-2 py-2 text-sm text-left hover:bg-cert-red hover:text-white cursor-pointer"
+                    >
+                      {reference.type === "study" ? "스터디" : "프로젝트"} -{" "}
+                      {reference.title}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            <p className="text-xs text-gray-500 mt-2">
+              블로그를 작성하고자 하는 스터디, 프로젝트를 선택해주세요. (최대
+              1개)
+            </p>
+          </div>
+        </div>
       </div>
 
       {/* 카테고리 및 최대 참가자 수 */}

--- a/src/components/write/CCWriteForm.tsx
+++ b/src/components/write/CCWriteForm.tsx
@@ -228,7 +228,11 @@ export default function WriteForm({ type }: WriteFormProps) {
           <div className="relative">
             <button
               type="button"
-              onClick={() => setIsSelecteReferenceOpen((prev) => !prev)}
+              onClick={() => {
+                setIsSelecteReferenceOpen((prev) => !prev);
+                setIsCategoryOpen(false);
+                setIsSubCategoryOpen(false);
+              }}
               className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm cursor-pointer"
             >
               <span
@@ -260,7 +264,7 @@ export default function WriteForm({ type }: WriteFormProps) {
                         setSelectedReference(reference);
                         setIsSelecteReferenceOpen(false);
                       }}
-                      className="w-full px-2 py-2 text-sm text-left hover:bg-cert-red hover:text-white cursor-pointer"
+                      className="relative flex w-full cursor-pointer select-none items-center rounded-sm py-2 px-2 text-sm outline-none transition-colors hover:bg-cert-red hover:text-white focus:bg-cert-red focus:text-white"
                     >
                       {reference.type === "study" ? "스터디" : "프로젝트"} -{" "}
                       {reference.title}

--- a/src/layouts/navigationBar.tsx
+++ b/src/layouts/navigationBar.tsx
@@ -21,7 +21,7 @@ const navBarList = [
 const NavigationBar = () => {
   return (
     <>
-      <nav className="fixed w-full bg-white/95 backdrop-blur-md border-b border-gray-200 top-0 z-20 transition-colors duration-300">
+      <nav className="fixed w-full bg-white/95 backdrop-blur-md border-b border-gray-200 top-0 z-25 transition-colors duration-300">
         <div className="max-w-7xl mx-auto px-4 lg:px-2 flex justify-between items-center">
           <Link href="/" className="flex items-center group h-16 ">
             <div className="relative w-10 h-10 mr-2">

--- a/src/mocks/blogData.ts
+++ b/src/mocks/blogData.ts
@@ -37,6 +37,11 @@ setTimeout(() => {
     likes: 45,
     featured: true,
     published: false,
+    reference: {
+      referenceId: 1,
+      type: "study",
+      title: "OWASP Top 10 2023 취약점 분석",
+    },
   },
   {
     id: 2,
@@ -73,6 +78,11 @@ setTimeout(() => {
     views: 890,
     likes: 32,
     published: true,
+    reference: {
+      referenceId: 2,
+      type: "study",
+      title: "Metasploit Framework 완전 정복",
+    },
   },
   {
     id: 3,
@@ -116,6 +126,11 @@ type UserWithoutId = Omit<User, 'id'>;
     views: 2100,
     likes: 78,
     published: true,
+    reference: {
+      referenceId: 1,
+      type: "project",
+      title: "Social Impact Hackathon 2025",
+    },
   },
   {
     id: 4,
@@ -162,6 +177,11 @@ def fibonacci(n):
     views: 1680,
     likes: 56,
     published: true,
+    reference: {
+      referenceId: 2,
+      type: "project",
+      title: "OWASP Top 10 2023 취약점 분석",
+    },
   },
   {
     id: 5,
@@ -214,6 +234,11 @@ spec:
     views: 1420,
     likes: 67,
     published: true,
+    reference: {
+      referenceId: 3,
+      type: "project",
+      title: "AI 기반 악성코드 탐지 시스템",
+    },
   },
   {
     id: 6,
@@ -248,6 +273,11 @@ spec:
     views: 980,
     likes: 42,
     published: true,
+    reference: {
+      referenceId: 1,
+      type: "study",
+      title: "OWASP Top 10 2023 취약점 분석",
+    },
   },
   {
     id: 7,
@@ -282,6 +312,11 @@ spec:
     views: 980,
     likes: 42,
     published: true,
+    reference: {
+      referenceId: 1,
+      type: "project",
+      title: "Social Impact Hackathon 2025",
+    },
   },
 ];
 

--- a/src/mocks/mockBoardData.ts
+++ b/src/mocks/mockBoardData.ts
@@ -11,9 +11,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "공지사항",
     views: 256,
     likes: 18,
-    comments: 12,
-    isNotice: true,
-    priority: "high",
   },
   {
     id: 2,
@@ -25,9 +22,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "보안이슈",
     views: 189,
     likes: 25,
-    comments: 8,
-    isNotice: false,
-    priority: "medium",
   },
   {
     id: 3,
@@ -39,9 +33,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "질문",
     views: 334,
     likes: 42,
-    comments: 15,
-    isNotice: false,
-    priority: "medium",
   },
   {
     id: 4,
@@ -53,9 +44,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "공지사항",
     views: 178,
     likes: 8,
-    comments: 5,
-    isNotice: true,
-    priority: "high",
   },
   {
     id: 5,
@@ -67,9 +55,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "질문",
     views: 145,
     likes: 19,
-    comments: 7,
-    isNotice: false,
-    priority: "low",
   },
   {
     id: 6,
@@ -81,9 +66,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "활동내용",
     views: 145,
     likes: 19,
-    comments: 7,
-    isNotice: false,
-    priority: "low",
   },
   {
     id: 7,
@@ -95,9 +77,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "활동내용",
     views: 145,
     likes: 19,
-    comments: 7,
-    isNotice: false,
-    priority: "low",
   },
   {
     id: 8,
@@ -109,9 +88,6 @@ export const mockBoardData: BoardDataType[] = [
     category: "활동내용",
     views: 145,
     likes: 19,
-    comments: 7,
-    isNotice: false,
-    priority: "low",
   },
   {
     id: 9,
@@ -123,8 +99,5 @@ export const mockBoardData: BoardDataType[] = [
     category: "활동내용",
     views: 145,
     likes: 19,
-    comments: 7,
-    isNotice: false,
-    priority: "low",
   },
 ];

--- a/src/mocks/mockProfileData.ts
+++ b/src/mocks/mockProfileData.ts
@@ -218,7 +218,12 @@ setTimeout(() => {
     views: 1250,
     likes: 45,
     featured: true,
-    published: true,
+    published: false,
+    reference: {
+      referenceId: 1,
+      type: "study",
+      title: "OWASP Top 10 2023 취약점 분석",
+    },
   },
   {
     id: 2,
@@ -255,5 +260,10 @@ setTimeout(() => {
     views: 890,
     likes: 32,
     published: true,
+    reference: {
+      referenceId: 2,
+      type: "study",
+      title: "Metasploit Framework 완전 정복",
+    },
   },
 ];

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -14,6 +14,12 @@ export type BlogCategory = (typeof BLOG_CATEGORIES)[number];
 // 페이지네이션 설정
 export const ITEMS_PER_PAGE = 6;
 
+export interface Reference {
+  referenceId: number;
+  type: "study" | "project";
+  title: string;
+}
+
 // 블로그 포스트 인터페이스
 export interface BlogPost {
   id: number;
@@ -30,6 +36,7 @@ export interface BlogPost {
   published: boolean;
   slug?: string;
   coverImage?: string;
+  reference: Reference;
 }
 
 // 블로그 필터 인터페이스

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -9,10 +9,6 @@ export const boardCategories = [
 
 export type BoardCategoryType = (typeof boardCategories)[number];
 
-export const boardPriorities = ["high", "medium", "low"] as const;
-
-export type BoardPriorityType = (typeof boardPriorities)[number];
-
 export interface BoardDataType {
   id: number;
   title: string;
@@ -22,7 +18,4 @@ export interface BoardDataType {
   category: BoardCategoryType;
   views: number;
   likes: number;
-  comments: number;
-  isNotice: boolean;
-  priority: BoardPriorityType;
 }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,4 +1,4 @@
-import { BlogCategory } from "./blog";
+import { BlogCategory, Reference } from "./blog";
 import BookSVG from "/public/icons/book.svg";
 import CommentSVG from "/public/icons/comment.svg";
 import { MembersDataType } from "@/types/members";
@@ -78,4 +78,5 @@ export interface ProfileBlogDataType {
   published: boolean;
   slug?: string;
   coverImage?: string;
+  reference: Reference;
 }

--- a/src/utils/boardUtils.ts
+++ b/src/utils/boardUtils.ts
@@ -43,7 +43,7 @@ export const getCategoryColor = (category: BoardCategoryType) => {
       return "bg-blue-50 text-blue-600 border-blue-200";
     case "활동내용":
       return "bg-green-50 text-green-600 border-green-200";
-    default:
+    case "질문":
       return "bg-gray-50 text-gray-600 border-gray-200";
   }
 };

--- a/src/utils/categoryColorUtils.ts
+++ b/src/utils/categoryColorUtils.ts
@@ -29,6 +29,7 @@ export const getCategoryColor = (
       return "bg-green-50 text-green-600 border-green-200";
     case "MISC":
       return "bg-sky-50 text-sky-600 border-sky-200";
+    case "기타":
     default:
       return "bg-gray-50 text-gray-600 border-gray-200";
   }

--- a/src/utils/membersUtils.ts
+++ b/src/utils/membersUtils.ts
@@ -18,9 +18,9 @@ export const getRoleBadgeStyle = (
       return "bg-blue-100 text-blue-800 border-blue-600";
     case "스터디장":
       return "bg-purple-100 text-purple-800 border-purple-600";
-    case "PLAYER":
-      return "bg-green-100 text-green-800 border-green-600";
     case "UPSOLVER":
+      return "bg-green-100 text-green-800 border-green-600";
+    case "PLAYER":
       return "bg-gray-100 text-gray-800 border-gray-600";
     case "NONE":
     case "전체":
@@ -40,9 +40,9 @@ export const getRoleBorderStyle = (
       return "hover:border-blue-600 group-hover:border-blue-600";
     case "스터디장":
       return "hover:border-purple-600 group-hover:border-purple-600";
-    case "PLAYER":
-      return "hover:border-green-600 group-hover:border-green-600";
     case "UPSOLVER":
+      return "hover:border-green-600 group-hover:border-green-600";
+    case "PLAYER":
       return "hover:border-gray-600 group-hover:border-gray-600";
     case "NONE":
     case "전체":
@@ -63,7 +63,7 @@ export const gradeOptions = [
   { value: "", label: "전체" },
   ...membersGradeCategories.map((grade) => ({
     value: grade.toString(),
-    label: `${grade}학년`,
+    label: `${grade}`,
   })),
 ];
 
@@ -103,10 +103,10 @@ const filterByRole = (
       return ["회장", "부회장", "임원진"].includes(member.role);
     case "스터디장":
       return member.role === "스터디장";
-    case "PLAYER":
-      return member.role === "PLAYER";
     case "UPSOLVER":
       return member.role === "UPSOLVER";
+    case "PLAYER":
+      return member.role === "PLAYER";
     case "NONE":
     case "전체":
       return true; // 전체 보기 or 역할 없음 → 모든 멤버 포함
@@ -129,10 +129,19 @@ export const filterMembers = (
   role: MembersRoleCategoryType | "전체",
   grade: MembersGradeCategoryType | "전체"
 ) => {
-  return members.filter(
-    (member) =>
-      filterBySearch(member, search) &&
-      filterByRole(member, role) &&
-      filterByGrade(member, grade)
-  );
+  return members
+    .filter(
+      (member) =>
+        filterBySearch(member, search) &&
+        filterByRole(member, role) &&
+        filterByGrade(member, grade)
+    )
+    .sort((a, b) => {
+      const roleDiff =
+        membersRoleCategories.indexOf(a.role) -
+        membersRoleCategories.indexOf(b.role);
+      if (roleDiff !== 0) return roleDiff;
+
+      return a.name.localeCompare(b.name, "ko-KR");
+    });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #59 

## 📝작업 내용
> ### 수정
> - Board
>     - 기존 우선순위 util 제거 -> 카테고리 = 공지사항 일 경우, bg-red로 수정 + 카테고리별 SVG 적용 util 추가
> - Schedule
>    - 캘린더에서 오늘 해당하는 날짜가 NavBar 뚫음 -> NavBar z-index 값 수정
> - Study
>    - 회의록 모달
>        - 인원수 입력칸 추가하기 
>        - 회의 링크가 아니라 회의 내용으로 수정하기
>        - 회의록 추가 시 bg-black 유지되는 에러 수정
> - Blog
>     - is_public 체크박스가 케밥 메뉴 뚫음 -> 케밥의 z-index 올리기
> - Members
>     - player와 upsolver 위치 변경
>     - 학년 드롭다운 오타 수정
> - Profile
>     - blog의 좋아요 제거

> ### 구현
> - Blog WriteForm 내 스터디/프로젝트 선택 드롭다운 추가
> - TOP 버튼 추가



### 스크린샷 (선택)
- WriteForm

https://github.com/user-attachments/assets/3ad34e6b-bc9c-41c0-9e88-9be25ab24273




- 서비스페이지 blog
<img width="1363" height="853" alt="스크린샷 2025-08-29 19 55 23" src="https://github.com/user-attachments/assets/8ab39de0-00c3-4e82-aa75-a01759f2b8a5" />
<img width="1265" height="798" alt="스크린샷 2025-08-29 19 55 27" src="https://github.com/user-attachments/assets/59be116d-443f-46a4-9be0-b3b74e68bcfe" />

- 어드민페이지 blog
<img width="1475" height="748" alt="image" src="https://github.com/user-attachments/assets/2039c1b1-867b-4f00-a972-1bff840155dd" />

- profile 
<img width="1343" height="866" alt="스크린샷 2025-08-29 20 03 51" src="https://github.com/user-attachments/assets/41c99a4d-5f3e-4290-b20c-1267038285b4" />


## 💬리뷰 요구사항(선택)

> UI 피드백 환영입니다람쥐
