### PR TITLE
Refactor: jwt refresh & login ui

### DIFF
--- a/src/actions/auth/LoginServerAction.tsx
+++ b/src/actions/auth/LoginServerAction.tsx
@@ -43,5 +43,5 @@ export async function loginAction(formData: FormData) {
   }
 
   // 로그인 성공 시 리다이렉트
-  return { success: true };
+  return { success: true, role: data.data.role };
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { ThemeProvider } from "next-themes";
+import AuthInitializer from "@/components/auth/AuthInitializer";
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL as string),
   title: "CERT-IS",
@@ -18,6 +19,7 @@ export default function RootLayout({
         ) : null}
       </head>
       <body className="overscroll-none">
+        <AuthInitializer />
         <ThemeProvider attribute="class">{children}</ThemeProvider>
         <div id="modal-root"></div>
       </body>

--- a/src/components/admin/login/CCAdminLoginForm.tsx
+++ b/src/components/admin/login/CCAdminLoginForm.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/navigation";
 export default function CCAdminLoginForm() {
   const { showPassword, setShowPassword, loginFormData, setLoginFormData } =
     useAuth();
-  const setIsLogin = useAuthStore((state) => state.setIsLogin);
+  const setAuth = useAuthStore((state) => state.setAuth);
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -22,7 +22,7 @@ export default function CCAdminLoginForm() {
       try {
         const result = await loginAction(formData);
         if (result.success) {
-          setIsLogin(true);
+          setAuth(true, result.role);
           router.push("/admin");
         } else {
           // 에러 처리 UI 추가 가능

--- a/src/components/auth/AuthInitializer.tsx
+++ b/src/components/auth/AuthInitializer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuthStore } from "@/store/authStore";
+import { apiClient } from "@/lib/clientIntercept";
+
+export default function AuthInitializer() {
+  const { setAuth, logout } = useAuthStore();
+
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const res = await apiClient.get("/profile/me");
+        const { data } = res.data;
+        setAuth(true, data.memberRole);
+      } catch {
+        logout();
+      }
+    }
+    checkAuth();
+  }, [setAuth, logout]);
+
+  return null;
+}

--- a/src/components/auth/login/CCLoginForm.tsx
+++ b/src/components/auth/login/CCLoginForm.tsx
@@ -13,7 +13,7 @@ import { useAuthStore } from "@/store/authStore";
 export default function CCLoginInput() {
   const { showPassword, setShowPassword, loginFormData, setLoginFormData } =
     useAuth();
-  const setIsLogin = useAuthStore((state) => state.setIsLogin);
+  const setAuth = useAuthStore((state) => state.setAuth);
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -22,7 +22,7 @@ export default function CCLoginInput() {
       try {
         const result = await loginAction(formData);
         if (result.success) {
-          setIsLogin(true);
+          setAuth(true, result.role);
           router.push("/");
         } else {
           console.log(result.message);

--- a/src/components/nav/loginButton.tsx
+++ b/src/components/nav/loginButton.tsx
@@ -8,20 +8,25 @@ import { logoutAction } from "@/actions/auth/LogoutServerAction"; // ✅ 서버 
 interface LoginButtonProps {
   className?: string;
   href?: string;
+  initialIsLogin?: boolean;
 }
 
 export default function LoginButton({
   className = "",
   href = "/login", // 기본값
+  initialIsLogin,
 }: LoginButtonProps) {
-  const { isLogin } = useAuthStore();
+  const { isLogin, logout } = useAuthStore();
 
   async function handleLogout() {
     await logoutAction(); // 서버 로그아웃 실행 (refreshToken 만료 + 쿠키 삭제)
+    logout(); // 클라이언트 상태 초기화
     window.location.href = "/login"; // ✅ 강제 새로고침 + 리다이렉트
   }
 
-  if (isLogin) {
+  const effectiveLogin = isLogin || initialIsLogin;
+
+  if (effectiveLogin) {
     return (
       <button
         onClick={handleLogout}

--- a/src/layouts/admin/adminNavigationBar.tsx
+++ b/src/layouts/admin/adminNavigationBar.tsx
@@ -5,6 +5,7 @@ import NavBarItems from "@/components/nav/navBarItems";
 import LogoSVG from "/public/icons/logo-white.svg";
 import LoginButton from "@/components/nav/loginButton";
 import HamburgerMenu from "@/components/nav/hamburgerMenu";
+import { cookies } from "next/headers";
 
 const navBarList = [
   { name: "Home", href: "/admin" },
@@ -14,7 +15,9 @@ const navBarList = [
   { name: "Members", href: "/admin/members" },
 ];
 
-export default function AdminNavigationBar() {
+export default async function AdminNavigationBar() {
+  const cookieStore = await cookies();
+  const initialIsLogin = !!cookieStore.get("accessToken");
   return (
     <>
       <nav className="fixed w-full bg-white/95 backdrop-blur-md border-b border-gray-200 top-0 z-20 transition-colors duration-300">
@@ -38,7 +41,11 @@ export default function AdminNavigationBar() {
           <div className="hidden md:flex flex-row items-center">
             <NavBarItems navBarList={navBarList} />
             <div className="pl-6 ml-2 border-l border-gray-300">
-              <LoginButton href="/admin/login" className="text-sm" />
+              <LoginButton
+                href="/admin/login"
+                className="text-sm"
+                initialIsLogin={initialIsLogin}
+              />
             </div>
           </div>
 

--- a/src/layouts/navigationBar.tsx
+++ b/src/layouts/navigationBar.tsx
@@ -6,6 +6,7 @@ import NavBarItems from "@/components/nav/navBarItems";
 import LogoSVG from "/public/icons/logo-white.svg";
 import LoginButton from "@/components/nav/loginButton";
 import HamburgerMenu from "@/components/nav/hamburgerMenu";
+import { cookies } from "next/headers";
 
 const navBarList = [
   { name: "Home", href: "/" },
@@ -18,7 +19,9 @@ const navBarList = [
   { name: "Profile", href: "/profile" },
 ];
 
-const NavigationBar = () => {
+const NavigationBar = async () => {
+  const cookieStore = await cookies();
+  const initialIsLogin = !!cookieStore.get("accessToken");
   return (
     <>
       <nav className="fixed w-full bg-white/95 backdrop-blur-md border-b border-gray-200 top-0 z-25 transition-colors duration-300 dark:bg-cert-darker dark:border-gray-700">
@@ -44,7 +47,10 @@ const NavigationBar = () => {
             <div className="pl-6 ml-2 border-l border-gray-300 dark:border-gray-700 flex-shrink-0">
               <BugReport className="text-sm" />
             </div>
-            <LoginButton className="text-sm flex-shrink-0" />
+            <LoginButton
+              className="text-sm flex-shrink-0"
+              initialIsLogin={initialIsLogin}
+            />
           </div>
 
           {/* 모바일 메뉴 */}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -34,7 +34,7 @@ export async function verifyJwt(token: string): Promise<JwtPayload> {
     return payload as JwtPayload;
   } catch (error) {
     console.error("JWT verification error");
-    throw new Error(`Invalid token: ${error}`);
+    throw error;
   }
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,70 +1,114 @@
-// import { NextRequest, NextResponse } from "next/server";
-// import { verifyJwt, isAdmin, getLoginUrlByPath } from "@/lib/auth/jwt";
-
-// // 공개 라우트 (인증 불필요)
-// const PUBLIC_ROUTES = [
-//   "/",
-//   "/login",
-//   "/admin/login",
-//   "/blog",
-//   "/members",
-//   "/403",
-//   "/404",
-//   "/signup",
-// ];
-
-// export async function middleware(req: NextRequest) {
-//   const { pathname } = req.nextUrl;
-
-//   //_next 경로란 Next.js가 빌드/실행 하면서 자동으로 붙이는 런타임 리소스 경로로 Next.js 내부에서 사용하는 파일들을 제공하는 경로입니다.
-//   if (PUBLIC_ROUTES.includes(pathname) || pathname.startsWith("/_next")) {
-//     return NextResponse.next();
-//   }
-
-//   const accessToken = req.cookies.get("accessToken")?.value;
-
-//   // accessToken이 없으면 도메인에 적절한 로그인 페이지로 리다이렉트
-//   if (!accessToken) {
-//     return redirectToLogin(req);
-//   }
-
-//   try {
-//     const payload = await verifyJwt(accessToken);
-
-//     // 관리자 페이지 접근 시 권한 확인
-//     if (pathname.startsWith("/admin") && !isAdmin(payload)) {
-//       const url = req.nextUrl.clone();
-//       url.pathname = "/403"; // 권한 없음 페이지로 리다이렉트
-//       return NextResponse.rewrite(url); // redirect 대신 SSR 렌더링
-//     }
-
-//     return NextResponse.next();
-//   } catch {
-//     return redirectToLogin(req);
-//   }
-// }
-
-// const redirectToLogin = (req: NextRequest) => {
-//   const loginUrl = getLoginUrlByPath(req.nextUrl.pathname);
-//   const url = req.nextUrl.clone();
-//   url.pathname = loginUrl;
-//   url.searchParams.set("returnTo", req.nextUrl.pathname + req.nextUrl.search); // 리다이렉트 후 돌아올 경로 설정
-//   return NextResponse.redirect(url);
-// };
-
-// export const config = {
-//   matcher: ["/((?!api|static|favicon.ico|public/).*)"], // api, static, favicon.ico, public 폴더는 미들웨어 적용 안함
-// };
-
-// 개발 편리성을 위한 임시 middleware 코드 -> 위의 코드로 사용해야 함
 import { NextRequest, NextResponse } from "next/server";
+import { verifyJwt, isAdmin, getLoginUrlByPath } from "@/lib/auth/jwt";
+import { errors } from "jose";
+
+// 공개 라우트 (인증 불필요)
+const PUBLIC_ROUTES = [
+  "/",
+  "/login",
+  "/admin/login",
+  "/blog",
+  "/members",
+  "/403",
+  "/404",
+  "/signup",
+];
 
 export async function middleware(req: NextRequest) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { pathname } = req.nextUrl;
-  return NextResponse.next();
+
+  // Next.js 내부 리소스 경로나 공개 라우트는 통과
+  if (PUBLIC_ROUTES.includes(pathname) || pathname.startsWith("/_next")) {
+    return NextResponse.next();
+  }
+
+  const accessToken = req.cookies.get("accessToken")?.value;
+  const refreshToken = req.cookies.get("refreshToken")?.value;
+
+  // accessToken, refreshToken 없으면 로그인으로 리다이렉트
+  if (!accessToken || !refreshToken) {
+    return redirectToLogin(req);
+  }
+
+  try {
+    // accessToken 유효성 검증
+    const payload = await verifyJwt(accessToken);
+
+    // 관리자 페이지 접근 시 권한 확인
+    if (pathname.startsWith("/admin") && !isAdmin(payload)) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/403"; // 권한 없음 페이지로
+      return NextResponse.rewrite(url);
+    }
+
+    return NextResponse.next();
+  } catch (err) {
+    // AccessToken 만료 → Refresh 시도
+    if (err instanceof errors.JWTExpired) {
+      console.log("🔑 AccessToken 만료됨 → Refresh 시도");
+
+      const API_URL = process.env.NEXT_PUBLIC_API_URL;
+      try {
+        const refreshRes = await fetch(`${API_URL}/auth/token/refresh`, {
+          method: "POST",
+          headers: {
+            Cookie: `refreshToken=${refreshToken}`,
+          },
+        });
+
+        if (!refreshRes.ok) {
+          console.error("❌ Refresh 실패:", refreshRes.status);
+          return redirectToLogin(req);
+        }
+
+        const body = await refreshRes.json();
+        const newAccessToken = body.data.accessToken;
+
+        // ✅ 새 accessToken 갱신
+        const res = NextResponse.next();
+        res.cookies.set("accessToken", newAccessToken, {
+          httpOnly: false,
+          secure: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: 60 * 15,
+        });
+
+        return res;
+      } catch (refreshErr) {
+        console.error("❌ Refresh 중 예외:", refreshErr);
+        return redirectToLogin(req);
+      }
+    }
+
+    // 그 외 검증 실패
+    console.error("❌ JWT 검증 실패:", err);
+    return redirectToLogin(req);
+  }
 }
+
+const redirectToLogin = (req: NextRequest) => {
+  const loginUrl = getLoginUrlByPath(req.nextUrl.pathname);
+  const url = req.nextUrl.clone();
+  url.pathname = loginUrl;
+  url.searchParams.set("returnTo", req.nextUrl.pathname + req.nextUrl.search); // 리다이렉트 후 돌아올 경로
+  return NextResponse.redirect(url);
+};
 
 export const config = {
   matcher: ["/((?!api|static|favicon.ico|public/).*)"],
+  // api, static, favicon.ico, public 폴더는 미들웨어 적용 안함
 };
+
+// // 개발 편리성을 위한 임시 middleware 코드 -> 위의 코드로 사용해야 함
+// import { NextRequest, NextResponse } from "next/server";
+
+// export async function middleware(req: NextRequest) {
+//   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+//   const { pathname } = req.nextUrl;
+//   return NextResponse.next();
+// }
+
+// export const config = {
+//   matcher: ["/((?!api|static|favicon.ico|public/).*)"],
+// };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -45,7 +45,7 @@ export async function middleware(req: NextRequest) {
   } catch (err) {
     // AccessToken 만료 → Refresh 시도
     if (err instanceof errors.JWTExpired) {
-      console.log("🔑 AccessToken 만료됨 → Refresh 시도");
+      console.log("AccessToken 만료됨 → Refresh 시도");
 
       const API_URL = process.env.NEXT_PUBLIC_API_URL;
       try {
@@ -57,32 +57,32 @@ export async function middleware(req: NextRequest) {
         });
 
         if (!refreshRes.ok) {
-          console.error("❌ Refresh 실패:", refreshRes.status);
+          console.error("Refresh 실패:", refreshRes.status);
           return redirectToLogin(req);
         }
 
         const body = await refreshRes.json();
         const newAccessToken = body.data.accessToken;
 
-        // ✅ 새 accessToken 갱신
+        //  새 accessToken 갱신
         const res = NextResponse.next();
         res.cookies.set("accessToken", newAccessToken, {
           httpOnly: false,
           secure: true,
           sameSite: "lax",
           path: "/",
-          maxAge: 60 * 15,
+          maxAge: 60 * 60, // 60초 * 60 = 1시간
         });
 
         return res;
       } catch (refreshErr) {
-        console.error("❌ Refresh 중 예외:", refreshErr);
+        console.error("Refresh 중 예외:", refreshErr);
         return redirectToLogin(req);
       }
     }
 
     // 그 외 검증 실패
-    console.error("❌ JWT 검증 실패:", err);
+    console.error("JWT 검증 실패:", err);
     return redirectToLogin(req);
   }
 }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,11 +1,23 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface AuthState {
   isLogin: boolean;
-  setIsLogin: (value: boolean) => void;
+  role: string | null;
+  setAuth: (isLogin: boolean, role: string | null) => void;
+  logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  isLogin: false,
-  setIsLogin: (value) => set({ isLogin: value }),
-}));
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      isLogin: false,
+      role: null,
+      setAuth: (isLogin, role) => set({ isLogin, role }),
+      logout: () => set({ isLogin: false, role: null }),
+    }),
+    {
+      name: "auth-storage", // 로컬스토리지 키 이름
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #69 

## 📝작업 내용

> 원래는 intercept를 사용해서 구현하려고 하던 리프레시 요청이었습니다. CSR 방식은 쉽게 구현이되지만 SSR 방식에서 쿠키를 주고 받는 과정에서 나타나는 문제점들이 있었습니다.
```
1. 서버액션 및 route.ts를 제외한 요청에서는 토큰을 브라우저에 직접 저장할 수 없습니다. ( fetchWithAuth에서 불가능 )
2. 서버액션 및 route.ts는 브라우저의 쿠키를 직접 읽을 수 없습니다. ( severAction, route.ts에서 불가능 )
그래서 SSR요청후 또 CSR로 요청을 해야하는데 이거는 너무 의미없는 요청 중복이 될 것같아 방법을 찾았습니다.
```

> middleware.ts에서 만료된 jwt를 받을시에 바로 리프레시 요청을 하도록 만들었습니다. 
해당 레이어에서 처리할시 서버사이드에서 ui가 보여지기전에 모든 작업이 끝나 좋은 사용자 경험을 가질 수 있습니다.
또한 해당레이어에서 처리할시 jwt인증이 필요한 도메인가 그렇지 않은 도메인을 쉽게 나누어 관리할 수 있습니다.

> 로그인 후 전역 상태관리시에 새로고침이나 새로 브라우저로 들어올실 accessToken으로 인증이 되었음에도 불구하고 logout버튼 대신 login버튼이 보이는 문제점이있었습니다. 해당 문제점 개선을 위해 persist를 사용하여 localstorage에 상태를 저장하여 관리하였습니다.
또한 해당 방법을 사용할시 refresh가 만료되어 재로그인이 필요한 순간에도 localstorage캐시가 남아 여전히 로그인 버튼이 남을 수 있어 해당 앱 실행시에 persist상태를 refresh하는 로직도 추가하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 빨리 딴거 할게요 감사합니다;;
