### PR TITLE
Fix, Feat: 각 도메인 별 ProfileImage 추가 + study, project 관련 에러 수정 + schedule 예약 시간 수정 #99

### DIFF
--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -13,11 +13,7 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getStatusColor } from "@/utils/badgeUtils";
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
-import {
-  MEMBER_GRADE_LABELS,
-  MemberGrade,
-  ParticipantType,
-} from "@/types/study";
+import { MEMBER_GRADE_LABELS, ParticipantType } from "@/types/study";
 import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { formatDate } from "@/utils/formatDateUtil";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -13,7 +13,11 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getStatusColor } from "@/utils/badgeUtils";
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
-import { MEMBER_GRADE_LABELS, MemberGrade } from "@/types/study";
+import {
+  MEMBER_GRADE_LABELS,
+  MemberGrade,
+  ParticipantType,
+} from "@/types/study";
 import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { formatDate } from "@/utils/formatDateUtil";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
@@ -280,16 +284,47 @@ export default async function ProjectDetailPage({
 
               <div className="mb-6 space-y-3">
                 {approvedMember.length > 0 ? (
-                  approvedMember.map(
-                    (participant: {
-                      id: number;
-                      memberId: number;
-                      memberName: string;
-                      memberGrade: MemberGrade;
-                      profileImageUrl?: string;
-                    }) => (
+                  approvedMember.map((participant: ParticipantType) => (
+                    <div
+                      key={participant.memberId}
+                      className="flex items-center gap-3"
+                    >
+                      <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                        {participant.profileImageUrl ? (
+                          <Image
+                            src={participant.profileImageUrl}
+                            alt={`${participant.memberName} 프로필`}
+                            fill
+                            className="object-cover"
+                          />
+                        ) : (
+                          <LogoSVG className="w-8 h-8 text-gray-400" />
+                        )}
+                      </div>
+                      <p className="text-sm font-medium text-black dark:text-white">
+                        {participant.memberName}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    참여 중인 멤버가 없습니다.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                  대기중 멤버 ({pendingMember.length})
+                </h4>
+                <div className="space-y-3">
+                  {pendingMember.length > 0 ? (
+                    pendingMember.map((participant: ParticipantType) => (
                       <div
-                        key={participant.id}
+                        key={participant.memberId}
                         className="flex items-center gap-3"
                       >
                         <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
@@ -310,62 +345,15 @@ export default async function ProjectDetailPage({
                         <p className="text-xs text-gray-500 dark:text-gray-400">
                           {MEMBER_GRADE_LABELS[participant.memberGrade]}
                         </p>
-                      </div>
-                    )
-                  )
-                ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    참여 중인 멤버가 없습니다.
-                  </p>
-                )}
-              </div>
 
-              <div>
-                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                  대기중 멤버 ({pendingMember.length})
-                </h4>
-                <div className="space-y-3">
-                  {pendingMember.length > 0 ? (
-                    pendingMember.map(
-                      (participant: {
-                        id: number;
-                        memberId: number;
-                        memberName: string;
-                        memberGrade: MemberGrade;
-                        profileImageUrl?: string;
-                      }) => (
-                        <div
-                          key={participant.id}
-                          className="flex items-center gap-3"
-                        >
-                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                            {participant.profileImageUrl ? (
-                              <Image
-                                src={participant.profileImageUrl}
-                                alt={`${participant.memberName} 프로필`}
-                                fill
-                                className="object-cover"
-                              />
-                            ) : (
-                              <LogoSVG className="w-8 h-8 text-gray-400" />
-                            )}
-                          </div>
-                          <p className="text-sm font-medium text-black dark:text-white">
-                            {participant.memberName}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                          </p>
-
-                          <div className="flex gap-2">
-                            <CCParticipantActionButtons
-                              memberId={participant.memberId}
-                              dataId={project.id}
-                            />
-                          </div>
+                        <div className="flex gap-2">
+                          <CCParticipantActionButtons
+                            memberId={participant.memberId}
+                            dataId={project.id}
+                          />
                         </div>
-                      )
-                    )
+                      </div>
+                    ))
                   ) : (
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       대기중인 멤버가 없습니다.

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   getProjectPendingParticipants,
 } from "@/app/api/project/SCProjectParticipantApi";
 import { getCurrentUser } from "@/lib/auth/currentUser";
+import LogoSVG from "/public/icons/logo.svg";
 
 interface ProjectDetailPageProps {
   params: { id: string };
@@ -282,15 +283,26 @@ export default async function ProjectDetailPage({
                   approvedMember.map(
                     (participant: {
                       id: number;
+                      memberId: number;
                       memberName: string;
                       memberGrade: MemberGrade;
+                      profileImageUrl?: string;
                     }) => (
                       <div
                         key={participant.id}
                         className="flex items-center gap-3"
                       >
-                        <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                          {participant.memberName[0]}
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                          {participant.profileImageUrl ? (
+                            <Image
+                              src={participant.profileImageUrl}
+                              alt={`${participant.memberName} 프로필`}
+                              fill
+                              className="object-cover"
+                            />
+                          ) : (
+                            <LogoSVG className="w-8 h-8 text-gray-400" />
+                          )}
                         </div>
                         <p className="text-sm font-medium text-black dark:text-white">
                           {participant.memberName}
@@ -317,15 +329,26 @@ export default async function ProjectDetailPage({
                     pendingMember.map(
                       (participant: {
                         id: number;
+                        memberId: number;
                         memberName: string;
                         memberGrade: MemberGrade;
+                        profileImageUrl?: string;
                       }) => (
                         <div
                           key={participant.id}
                           className="flex items-center gap-3"
                         >
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                            {participant.memberName[0]}
+                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                            {participant.profileImageUrl ? (
+                              <Image
+                                src={participant.profileImageUrl}
+                                alt={`${participant.memberName} 프로필`}
+                                fill
+                                className="object-cover"
+                              />
+                            ) : (
+                              <LogoSVG className="w-8 h-8 text-gray-400" />
+                            )}
                           </div>
                           <p className="text-sm font-medium text-black dark:text-white">
                             {participant.memberName}
@@ -336,7 +359,8 @@ export default async function ProjectDetailPage({
 
                           <div className="flex gap-2">
                             <CCParticipantActionButtons
-                              participantId={participant.id}
+                              memberId={participant.memberId}
+                              dataId={project.id}
                             />
                           </div>
                         </div>

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -18,7 +18,6 @@ import { formatDate } from "@/utils/formatDateUtil";
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
 import {
   MEMBER_GRADE_LABELS,
-  MemberGrade,
   ParticipantType,
   StudyMaterial,
 } from "@/types/study";

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -1,3 +1,5 @@
+"server-only";
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import { Calendar, Users, Download } from "lucide-react";
 import DefaultBadge from "@/components/ui/defaultBadge";
@@ -24,6 +26,7 @@ import {
 } from "@/app/api/study/SCStudyParticipantApi";
 import { getCurrentUser } from "@/lib/auth/currentUser";
 import { getDetailStudy } from "@/app/api/study/SCStudyApi";
+import LogoSVG from "/public/icons/logo.svg";
 
 interface StudyDetailPageProps {
   params: { id: string };
@@ -198,8 +201,17 @@ export default async function StudyDetailPage({
                 스터디 리더
               </h3>
               <div className="flex items-center gap-3">
-                <div className="w-12 h-12 bg-cert-red rounded-full flex items-center justify-center text-white font-medium">
-                  {studyData.studyCreatorName[0]}
+                <div className="relative w-12 h-12 rounded-full overflow-hidden bg-gray-100 flex items-center justify-center font-medium">
+                  {studyData.studyCreatorProfileImageUrl ? (
+                    <Image
+                      src={studyData.studyCreatorProfileImageUrl}
+                      alt={`${studyData.studyCreatorName} 프로필`}
+                      fill
+                      className="object-cover"
+                    />
+                  ) : (
+                    <LogoSVG className="w-12 h-12 text-gray-400" />
+                  )}
                 </div>
                 <div>
                   <p className="font-medium text-black dark:text-white">
@@ -225,15 +237,26 @@ export default async function StudyDetailPage({
                     approvedMember.map(
                       (participant: {
                         id: number;
+                        memberId: number;
                         memberName: string;
                         memberGrade: MemberGrade;
+                        profileImageUrl?: string;
                       }) => (
                         <div
                           key={participant.id}
                           className="flex items-center gap-3"
                         >
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                            {participant.memberName[0]}
+                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                            {participant.profileImageUrl ? (
+                              <Image
+                                src={participant.profileImageUrl}
+                                alt={`${participant.memberName} 프로필`}
+                                fill
+                                className="object-cover"
+                              />
+                            ) : (
+                              <LogoSVG className="w-8 h-8 text-gray-400" />
+                            )}
                           </div>
                           <p className="text-sm font-medium text-black dark:text-white">
                             {participant.memberName}
@@ -261,15 +284,26 @@ export default async function StudyDetailPage({
                     pendingMember.map(
                       (participant: {
                         id: number;
+                        memberId: number;
                         memberName: string;
                         memberGrade: MemberGrade;
+                        profileImageUrl?: string;
                       }) => (
                         <div
                           key={participant.id}
                           className="flex items-center gap-3"
                         >
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                            {participant.memberName[0]}
+                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                            {participant.profileImageUrl ? (
+                              <Image
+                                src={participant.profileImageUrl}
+                                alt={`${participant.memberName} 프로필`}
+                                fill
+                                className="object-cover"
+                              />
+                            ) : (
+                              <LogoSVG className="w-8 h-8 text-gray-400" />
+                            )}
                           </div>
                           <p className="text-sm font-medium text-black dark:text-white">
                             {participant.memberName}
@@ -280,7 +314,8 @@ export default async function StudyDetailPage({
 
                           <div className="flex gap-2">
                             <CCParticipantActionButtons
-                              participantId={participant.id}
+                              memberId={participant.memberId}
+                              dataId={studyData.id}
                             />
                           </div>
                         </div>

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -16,7 +16,12 @@ import { getStatusColor } from "@/utils/badgeUtils";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { formatDate } from "@/utils/formatDateUtil";
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
-import { MEMBER_GRADE_LABELS, MemberGrade, StudyMaterial } from "@/types/study";
+import {
+  MEMBER_GRADE_LABELS,
+  MemberGrade,
+  ParticipantType,
+  StudyMaterial,
+} from "@/types/study";
 import CCShareButton from "@/components/detail/CCShareButton";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
 import { AttachedFile } from "@/types/attachedFile";
@@ -234,39 +239,31 @@ export default async function StudyDetailPage({
               <div className="mb-6">
                 <div className="space-y-3">
                   {approvedMember.length > 0 ? (
-                    approvedMember.map(
-                      (participant: {
-                        id: number;
-                        memberId: number;
-                        memberName: string;
-                        memberGrade: MemberGrade;
-                        profileImageUrl?: string;
-                      }) => (
-                        <div
-                          key={participant.id}
-                          className="flex items-center gap-3"
-                        >
-                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                            {participant.profileImageUrl ? (
-                              <Image
-                                src={participant.profileImageUrl}
-                                alt={`${participant.memberName} 프로필`}
-                                fill
-                                className="object-cover"
-                              />
-                            ) : (
-                              <LogoSVG className="w-8 h-8 text-gray-400" />
-                            )}
-                          </div>
-                          <p className="text-sm font-medium text-black dark:text-white">
-                            {participant.memberName}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                          </p>
+                    approvedMember.map((participant: ParticipantType) => (
+                      <div
+                        key={participant.memberId}
+                        className="flex items-center gap-3"
+                      >
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                          {participant.profileImageUrl ? (
+                            <Image
+                              src={participant.profileImageUrl}
+                              alt={`${participant.memberName} 프로필`}
+                              fill
+                              className="object-cover"
+                            />
+                          ) : (
+                            <LogoSVG className="w-8 h-8 text-gray-400" />
+                          )}
                         </div>
-                      )
-                    )
+                        <p className="text-sm font-medium text-black dark:text-white">
+                          {participant.memberName}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                        </p>
+                      </div>
+                    ))
                   ) : (
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       참여 중인 멤버가 없습니다.
@@ -281,46 +278,38 @@ export default async function StudyDetailPage({
                 </h4>
                 <div className="space-y-3">
                   {pendingMember.length > 0 ? (
-                    pendingMember.map(
-                      (participant: {
-                        id: number;
-                        memberId: number;
-                        memberName: string;
-                        memberGrade: MemberGrade;
-                        profileImageUrl?: string;
-                      }) => (
-                        <div
-                          key={participant.id}
-                          className="flex items-center gap-3"
-                        >
-                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                            {participant.profileImageUrl ? (
-                              <Image
-                                src={participant.profileImageUrl}
-                                alt={`${participant.memberName} 프로필`}
-                                fill
-                                className="object-cover"
-                              />
-                            ) : (
-                              <LogoSVG className="w-8 h-8 text-gray-400" />
-                            )}
-                          </div>
-                          <p className="text-sm font-medium text-black dark:text-white">
-                            {participant.memberName}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                          </p>
-
-                          <div className="flex gap-2">
-                            <CCParticipantActionButtons
-                              memberId={participant.memberId}
-                              dataId={studyData.id}
+                    pendingMember.map((participant: ParticipantType) => (
+                      <div
+                        key={participant.memberId}
+                        className="flex items-center gap-3"
+                      >
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                          {participant.profileImageUrl ? (
+                            <Image
+                              src={participant.profileImageUrl}
+                              alt={`${participant.memberName} 프로필`}
+                              fill
+                              className="object-cover"
                             />
-                          </div>
+                          ) : (
+                            <LogoSVG className="w-8 h-8 text-gray-400" />
+                          )}
                         </div>
-                      )
-                    )
+                        <p className="text-sm font-medium text-black dark:text-white">
+                          {participant.memberName}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                        </p>
+
+                        <div className="flex gap-2">
+                          <CCParticipantActionButtons
+                            memberId={participant.memberId}
+                            dataId={studyData.id}
+                          />
+                        </div>
+                      </div>
+                    ))
                   ) : (
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       대기중인 멤버가 없습니다.

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -106,7 +106,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
         {/* 블로그 카드 목록 */}
         {blogs.length > 0 ? (
           <Suspense
-            key={(await searchParams).keyword}
+            key={JSON.stringify({ keyword, category, page })}
             fallback={<SCBlogSkeleton />}
           >
             <BlogCardList blogs={blogs} />

--- a/src/app/(main)/board/[id]/page.tsx
+++ b/src/app/(main)/board/[id]/page.tsx
@@ -1,5 +1,5 @@
 "server-only";
-
+import Image from "next/image";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import BackToListButton from "@/components/detail/SCBackToListButton";
@@ -18,6 +18,7 @@ import { toKoreanCategory } from "@/types/board";
 import { formatDate } from "@/utils/formatDateUtil";
 import { AttachedFile, getFileKey } from "@/types/attachedFile";
 import { translateRoleToKorean } from "@/utils/transformRequestValue";
+import LogoSVG from "/public/icons/logo.svg";
 
 export async function generateMetadata({
   params,
@@ -100,8 +101,17 @@ export default async function DetailPage({
 
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center text-gray-600 font-medium">
-                {data.author.name.charAt(0)}
+              <div className="relative w-12 h-12 rounded-full overflow-hidden bg-gray-100 flex items-center justify-center text-gray-600 font-medium">
+                {data.author.profileImageUrl ? (
+                  <Image
+                    src={data.author.profileImageUrl}
+                    alt={`${data.author.name} 프로필`}
+                    fill
+                    className="object-cover"
+                  />
+                ) : (
+                  <LogoSVG className="w-12 h-12 text-gray-400" />
+                )}
               </div>
               <div>
                 <div className="flex items-center gap-2">

--- a/src/app/(main)/board/page.tsx
+++ b/src/app/(main)/board/page.tsx
@@ -105,7 +105,7 @@ export default async function BoardPage({ searchParams }: BoardPageProps) {
       </div>
 
       <Suspense
-        key={(await searchParams).keyword}
+        key={JSON.stringify({ keyword, category, page })}
         fallback={<SCBoardSkeleton />}
       >
         <BoardCardList contents={contents} />

--- a/src/app/(main)/members/page.tsx
+++ b/src/app/(main)/members/page.tsx
@@ -81,7 +81,7 @@ export default async function MembersPage({ searchParams }: MembersPageProps) {
         </div>
       </div>
       <Suspense
-        key={(await searchParams).keyword}
+        key={JSON.stringify({ keyword, role, grade })}
         fallback={<SCMembersSkeleton />}
       >
         <MembersCardList members={members} />

--- a/src/app/(main)/project/[id]/page.tsx
+++ b/src/app/(main)/project/[id]/page.tsx
@@ -13,7 +13,11 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { getStatusColor } from "@/utils/badgeUtils";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getDetailProject } from "@/app/api/project/SCProjectApi";
-import { MEMBER_GRADE_LABELS, MemberGrade } from "@/types/study";
+import {
+  MEMBER_GRADE_LABELS,
+  MemberGrade,
+  ParticipantType,
+} from "@/types/study";
 import { formatDate } from "@/utils/formatDateUtil";
 import { getCurrentUser } from "@/lib/auth/currentUser";
 import {
@@ -352,39 +356,31 @@ export default async function ProjectDetailPage({
 
               <div className="mb-6 space-y-3">
                 {approvedMember.length > 0 ? (
-                  approvedMember.map(
-                    (participant: {
-                      id: number;
-                      memberId: number;
-                      memberName: string;
-                      memberGrade: MemberGrade;
-                      profileImageUrl?: string;
-                    }) => (
-                      <div
-                        key={participant.id}
-                        className="flex items-center gap-3"
-                      >
-                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                          {participant.profileImageUrl ? (
-                            <Image
-                              src={participant.profileImageUrl}
-                              alt={`${participant.memberName} 프로필`}
-                              fill
-                              className="object-cover"
-                            />
-                          ) : (
-                            <LogoSVG className="w-8 h-8 text-gray-400" />
-                          )}
-                        </div>
-                        <p className="text-sm font-medium text-black dark:text-white">
-                          {participant.memberName}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                        </p>
+                  approvedMember.map((participant: ParticipantType) => (
+                    <div
+                      key={participant.memberId}
+                      className="flex items-center gap-3"
+                    >
+                      <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                        {participant.profileImageUrl ? (
+                          <Image
+                            src={participant.profileImageUrl}
+                            alt={`${participant.memberName} 프로필`}
+                            fill
+                            className="object-cover"
+                          />
+                        ) : (
+                          <LogoSVG className="w-8 h-8 text-gray-400" />
+                        )}
                       </div>
-                    )
-                  )
+                      <p className="text-sm font-medium text-black dark:text-white">
+                        {participant.memberName}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                      </p>
+                    </div>
+                  ))
                 ) : (
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     참여 중인 멤버가 없습니다.
@@ -399,47 +395,39 @@ export default async function ProjectDetailPage({
                   </h4>
                   <div className="space-y-3">
                     {pendingMember.length > 0 ? (
-                      pendingMember.map(
-                        (participant: {
-                          id: number;
-                          memberId: number;
-                          memberName: string;
-                          memberGrade: MemberGrade;
-                          profileImageUrl?: string;
-                        }) => (
-                          <div
-                            key={participant.id}
-                            className="flex items-center gap-3"
-                          >
-                            <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                              {participant.profileImageUrl ? (
-                                <Image
-                                  src={participant.profileImageUrl}
-                                  alt={`${participant.memberName} 프로필`}
-                                  fill
-                                  className="object-cover"
-                                />
-                              ) : (
-                                <LogoSVG className="w-8 h-8 text-gray-400" />
-                              )}
-                            </div>
-                            <p className="text-sm font-medium text-black dark:text-white">
-                              {participant.memberName}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">
-                              {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                            </p>
-                            {canApproveOrReject && (
-                              <div className="flex gap-2">
-                                <CCParticipantActionButtons
-                                  memberId={participant.memberId}
-                                  dataId={project.id}
-                                />
-                              </div>
+                      pendingMember.map((participant: ParticipantType) => (
+                        <div
+                          key={participant.memberId}
+                          className="flex items-center gap-3"
+                        >
+                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                            {participant.profileImageUrl ? (
+                              <Image
+                                src={participant.profileImageUrl}
+                                alt={`${participant.memberName} 프로필`}
+                                fill
+                                className="object-cover"
+                              />
+                            ) : (
+                              <LogoSVG className="w-8 h-8 text-gray-400" />
                             )}
                           </div>
-                        )
-                      )
+                          <p className="text-sm font-medium text-black dark:text-white">
+                            {participant.memberName}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                          </p>
+                          {canApproveOrReject && (
+                            <div className="flex gap-2">
+                              <CCParticipantActionButtons
+                                memberId={participant.memberId}
+                                dataId={project.id}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      ))
                     ) : (
                       <p className="text-sm text-gray-500 dark:text-gray-400">
                         대기중인 멤버가 없습니다.

--- a/src/app/(main)/project/[id]/page.tsx
+++ b/src/app/(main)/project/[id]/page.tsx
@@ -13,11 +13,7 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { getStatusColor } from "@/utils/badgeUtils";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getDetailProject } from "@/app/api/project/SCProjectApi";
-import {
-  MEMBER_GRADE_LABELS,
-  MemberGrade,
-  ParticipantType,
-} from "@/types/study";
+import { MEMBER_GRADE_LABELS, ParticipantType } from "@/types/study";
 import { formatDate } from "@/utils/formatDateUtil";
 import { getCurrentUser } from "@/lib/auth/currentUser";
 import {

--- a/src/app/(main)/project/[id]/page.tsx
+++ b/src/app/(main)/project/[id]/page.tsx
@@ -23,10 +23,10 @@ import {
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
 import { CCJoinButton } from "@/components/ui/CCJoinButton";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
-
 import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { ProjectMaterial } from "@/types/project";
 import { getStudyPeriodLabel } from "@/utils/studyHelper";
+import LogoSVG from "/public/icons/logo.svg";
 
 interface ProjectDetailPageProps {
   params: Promise<{ id: string }>;
@@ -355,15 +355,26 @@ export default async function ProjectDetailPage({
                   approvedMember.map(
                     (participant: {
                       id: number;
+                      memberId: number;
                       memberName: string;
                       memberGrade: MemberGrade;
+                      profileImageUrl?: string;
                     }) => (
                       <div
                         key={participant.id}
                         className="flex items-center gap-3"
                       >
-                        <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                          {participant.memberName[0]}
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                          {participant.profileImageUrl ? (
+                            <Image
+                              src={participant.profileImageUrl}
+                              alt={`${participant.memberName} 프로필`}
+                              fill
+                              className="object-cover"
+                            />
+                          ) : (
+                            <LogoSVG className="w-8 h-8 text-gray-400" />
+                          )}
                         </div>
                         <p className="text-sm font-medium text-black dark:text-white">
                           {participant.memberName}
@@ -391,15 +402,26 @@ export default async function ProjectDetailPage({
                       pendingMember.map(
                         (participant: {
                           id: number;
+                          memberId: number;
                           memberName: string;
                           memberGrade: MemberGrade;
+                          profileImageUrl?: string;
                         }) => (
                           <div
                             key={participant.id}
                             className="flex items-center gap-3"
                           >
-                            <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                              {participant.memberName[0]}
+                            <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                              {participant.profileImageUrl ? (
+                                <Image
+                                  src={participant.profileImageUrl}
+                                  alt={`${participant.memberName} 프로필`}
+                                  fill
+                                  className="object-cover"
+                                />
+                              ) : (
+                                <LogoSVG className="w-8 h-8 text-gray-400" />
+                              )}
                             </div>
                             <p className="text-sm font-medium text-black dark:text-white">
                               {participant.memberName}
@@ -410,7 +432,8 @@ export default async function ProjectDetailPage({
                             {canApproveOrReject && (
                               <div className="flex gap-2">
                                 <CCParticipantActionButtons
-                                  participantId={participant.id}
+                                  memberId={participant.memberId}
+                                  dataId={project.id}
                                 />
                               </div>
                             )}

--- a/src/app/(main)/project/page.tsx
+++ b/src/app/(main)/project/page.tsx
@@ -20,7 +20,7 @@ interface ProjectPageProps {
     semester?: string;
     category?: string;
     subCategory?: string;
-    status?: string;
+    projectStatus?: string;
     page?: string;
   }>;
 }
@@ -73,7 +73,8 @@ export async function generateMetadata({
 
 export default async function ProjectPage({ searchParams }: ProjectPageProps) {
   const resolvedSearchParams = await searchParams;
-
+  const { search, category, page, projectStatus, semester } =
+    resolvedSearchParams;
   const filters: ProjectCurrentFilters =
     parseSearchParams(resolvedSearchParams);
 
@@ -92,7 +93,13 @@ export default async function ProjectPage({ searchParams }: ProjectPageProps) {
         </Link>
       </div>
       <Suspense
-        key={(await searchParams).search}
+        key={JSON.stringify({
+          search,
+          category,
+          page,
+          projectStatus,
+          semester,
+        })}
         fallback={<SCProjectSkeleton />}
       >
         <SCProjectList searchParams={searchParams} />

--- a/src/app/(main)/schedule/page.tsx
+++ b/src/app/(main)/schedule/page.tsx
@@ -1,3 +1,6 @@
+"server-only";
+
+import { Suspense } from "react";
 import SCScheduleInfo from "@/components/schedule/SCScheduleInfo";
 import SCScheduleList from "@/components/schedule/SCScheduleList";
 import Calendar from "@/components/schedule/calendar";
@@ -7,6 +10,7 @@ import { getSchedules } from "@/app/api/schedule/SCscheduleApi";
 import { ScheduleInfo } from "@/types/schedule";
 import SCScheduleRequestList from "@/components/schedule/SCScheduleRequestList";
 import CCAddScheduleCard from "@/components/schedule/CCAddScheduleCard";
+import SCScheduleSkeleton from "@/components/schedule/SCScheduleSkeleton";
 
 interface SearchPageProps {
   searchParams: Promise<{ date: string }>;
@@ -44,6 +48,7 @@ function toLocalDate(date: string | Date) {
   const d = typeof date === "string" ? new Date(date) : date;
   return d.toISOString().split("T")[0];
 }
+
 export default async function SchedulePage({ searchParams }: SearchPageProps) {
   const resolvedSearchParams = await searchParams;
 
@@ -59,21 +64,23 @@ export default async function SchedulePage({ searchParams }: SearchPageProps) {
         <div className="absolute right-4 top-40 sm:hidden z-10">
           <CCScrollScheduleList />
         </div>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="md:col-span-2">
-            <Calendar schedules={schedules} selectedDate={selectedDate} />
-          </div>
-          <div>
-            <CCAddScheduleCard />
 
-            <div className="relative">
-              <SCScheduleInfo selectedDate={selectedDate} />
+        <Suspense fallback={<SCScheduleSkeleton />}>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            <div className="md:col-span-2">
+              <Calendar schedules={schedules} selectedDate={selectedDate} />
             </div>
-            <SCScheduleRequestList />
+            <div>
+              <CCAddScheduleCard />
+              <div className="relative">
+                <SCScheduleInfo selectedDate={selectedDate} />
+              </div>
+              <SCScheduleRequestList />
+            </div>
           </div>
-        </div>
 
-        <SCScheduleList id="all-schedule-list" date={selectedDate ?? ""} />
+          <SCScheduleList id="all-schedule-list" date={selectedDate ?? ""} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/app/(main)/study/[id]/page.tsx
+++ b/src/app/(main)/study/[id]/page.tsx
@@ -29,7 +29,6 @@ import MeetingMinutes from "@/components/study/SCStudyMeetingMinutes";
 import { AttachedFile } from "@/types/attachedFile";
 import {
   MEMBER_GRADE_LABELS,
-  MemberGrade,
   ParticipantType,
   StudyMaterial,
 } from "@/types/study";

--- a/src/app/(main)/study/[id]/page.tsx
+++ b/src/app/(main)/study/[id]/page.tsx
@@ -27,7 +27,12 @@ import { getCurrentUser } from "@/lib/auth/currentUser";
 import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
 import MeetingMinutes from "@/components/study/SCStudyMeetingMinutes";
 import { AttachedFile } from "@/types/attachedFile";
-import { MEMBER_GRADE_LABELS, MemberGrade, StudyMaterial } from "@/types/study";
+import {
+  MEMBER_GRADE_LABELS,
+  MemberGrade,
+  ParticipantType,
+  StudyMaterial,
+} from "@/types/study";
 import LogoSVG from "/public/icons/logo.svg";
 
 // 메타데이터 생성
@@ -310,16 +315,49 @@ export default async function StudyMaterialDetailPage({
               <div className="mb-6">
                 <div className="space-y-3">
                   {approvedMember.length > 0 ? (
-                    approvedMember.map(
-                      (participant: {
-                        id: number;
-                        memberId: number;
-                        memberName: string;
-                        memberGrade: MemberGrade;
-                        profileImageUrl?: string;
-                      }) => (
+                    approvedMember.map((participant: ParticipantType) => (
+                      <div
+                        key={participant.memberId}
+                        className="flex items-center gap-3"
+                      >
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                          {participant.profileImageUrl ? (
+                            <Image
+                              src={participant.profileImageUrl}
+                              alt={`${participant.memberName} 프로필`}
+                              fill
+                              className="object-cover"
+                            />
+                          ) : (
+                            <LogoSVG className="w-8 h-8 text-gray-400" />
+                          )}
+                        </div>
+                        <p className="text-sm font-medium text-black dark:text-white">
+                          {participant.memberName}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      참여 중인 멤버가 없습니다.
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {canApproveOrReject && (
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                    대기중 멤버 ({pendingMember.length})
+                  </h4>
+                  <div className="space-y-3">
+                    {pendingMember.length > 0 ? (
+                      pendingMember.map((participant: ParticipantType) => (
                         <div
-                          key={participant.id}
+                          key={participant.memberId}
                           className="flex items-center gap-3"
                         >
                           <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
@@ -340,66 +378,17 @@ export default async function StudyMaterialDetailPage({
                           <p className="text-xs text-gray-500 dark:text-gray-400">
                             {MEMBER_GRADE_LABELS[participant.memberGrade]}
                           </p>
-                        </div>
-                      )
-                    )
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      참여 중인 멤버가 없습니다.
-                    </p>
-                  )}
-                </div>
-              </div>
 
-              {canApproveOrReject && (
-                <div>
-                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                    대기중 멤버 ({pendingMember.length})
-                  </h4>
-                  <div className="space-y-3">
-                    {pendingMember.length > 0 ? (
-                      pendingMember.map(
-                        (participant: {
-                          id: number;
-                          memberId: number;
-                          memberName: string;
-                          memberGrade: MemberGrade;
-                          profileImageUrl?: string;
-                        }) => (
-                          <div
-                            key={participant.id}
-                            className="flex items-center gap-3"
-                          >
-                            <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                              {participant.profileImageUrl ? (
-                                <Image
-                                  src={participant.profileImageUrl}
-                                  alt={`${participant.memberName} 프로필`}
-                                  fill
-                                  className="object-cover"
-                                />
-                              ) : (
-                                <LogoSVG className="w-8 h-8 text-gray-400" />
-                              )}
+                          {canApproveOrReject && (
+                            <div className="flex gap-2">
+                              <CCParticipantActionButtons
+                                memberId={participant.memberId}
+                                dataId={studyData.id}
+                              />
                             </div>
-                            <p className="text-sm font-medium text-black dark:text-white">
-                              {participant.memberName}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">
-                              {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                            </p>
-
-                            {canApproveOrReject && (
-                              <div className="flex gap-2">
-                                <CCParticipantActionButtons
-                                  memberId={participant.memberId}
-                                  dataId={studyData.id}
-                                />
-                              </div>
-                            )}
-                          </div>
-                        )
-                      )
+                          )}
+                        </div>
+                      ))
                     ) : (
                       <p className="text-sm text-gray-500 dark:text-gray-400">
                         대기중인 멤버가 없습니다.

--- a/src/app/(main)/study/[id]/page.tsx
+++ b/src/app/(main)/study/[id]/page.tsx
@@ -1,5 +1,5 @@
 "server-only";
-
+import Image from "next/image";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Calendar, Users, Download } from "lucide-react";
@@ -28,6 +28,7 @@ import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButto
 import MeetingMinutes from "@/components/study/SCStudyMeetingMinutes";
 import { AttachedFile } from "@/types/attachedFile";
 import { MEMBER_GRADE_LABELS, MemberGrade, StudyMaterial } from "@/types/study";
+import LogoSVG from "/public/icons/logo.svg";
 
 // 메타데이터 생성
 export async function generateMetadata({
@@ -276,8 +277,17 @@ export default async function StudyMaterialDetailPage({
                 스터디 리더
               </h3>
               <div className="flex items-center gap-3">
-                <div className="w-12 h-12 bg-cert-red rounded-full flex items-center justify-center text-white font-medium">
-                  {studyData.studyCreatorName[0]}
+                <div className="relative w-12 h-12 rounded-full overflow-hidden bg-gray-100 flex items-center justify-center font-medium">
+                  {studyData.studyCreatorProfileImageUrl ? (
+                    <Image
+                      src={studyData.studyCreatorProfileImageUrl}
+                      alt={`${studyData.studyCreatorName} 프로필`}
+                      fill
+                      className="object-cover"
+                    />
+                  ) : (
+                    <LogoSVG className="w-12 h-12 text-gray-400" />
+                  )}
                 </div>
                 <div>
                   <p className="font-medium text-black dark:text-white">
@@ -303,15 +313,26 @@ export default async function StudyMaterialDetailPage({
                     approvedMember.map(
                       (participant: {
                         id: number;
+                        memberId: number;
                         memberName: string;
                         memberGrade: MemberGrade;
+                        profileImageUrl?: string;
                       }) => (
                         <div
                           key={participant.id}
                           className="flex items-center gap-3"
                         >
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                            {participant.memberName[0]}
+                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                            {participant.profileImageUrl ? (
+                              <Image
+                                src={participant.profileImageUrl}
+                                alt={`${participant.memberName} 프로필`}
+                                fill
+                                className="object-cover"
+                              />
+                            ) : (
+                              <LogoSVG className="w-8 h-8 text-gray-400" />
+                            )}
                           </div>
                           <p className="text-sm font-medium text-black dark:text-white">
                             {participant.memberName}
@@ -340,15 +361,26 @@ export default async function StudyMaterialDetailPage({
                       pendingMember.map(
                         (participant: {
                           id: number;
+                          memberId: number;
                           memberName: string;
                           memberGrade: MemberGrade;
+                          profileImageUrl?: string;
                         }) => (
                           <div
                             key={participant.id}
                             className="flex items-center gap-3"
                           >
-                            <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center text-black text-xs font-medium">
-                              {participant.memberName[0]}
+                            <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
+                              {participant.profileImageUrl ? (
+                                <Image
+                                  src={participant.profileImageUrl}
+                                  alt={`${participant.memberName} 프로필`}
+                                  fill
+                                  className="object-cover"
+                                />
+                              ) : (
+                                <LogoSVG className="w-8 h-8 text-gray-400" />
+                              )}
                             </div>
                             <p className="text-sm font-medium text-black dark:text-white">
                               {participant.memberName}
@@ -360,7 +392,8 @@ export default async function StudyMaterialDetailPage({
                             {canApproveOrReject && (
                               <div className="flex gap-2">
                                 <CCParticipantActionButtons
-                                  participantId={participant.id}
+                                  memberId={participant.memberId}
+                                  dataId={studyData.id}
                                 />
                               </div>
                             )}

--- a/src/app/(main)/study/page.tsx
+++ b/src/app/(main)/study/page.tsx
@@ -32,6 +32,7 @@ export async function generateMetadata({
     category?: string;
     subCategory?: string;
     studyStatus?: string;
+    semester?: string;
   }>;
 }): Promise<Metadata> {
   const { search, category, subCategory } = await searchParams;
@@ -64,6 +65,8 @@ export async function generateMetadata({
 
 export default async function StudyPage({ searchParams }: StudyPageProps) {
   const resolvedSearchParams = await searchParams;
+  const { search, category, page, studyStatus, semester } =
+    resolvedSearchParams;
 
   // URL에서 필터 파라미터 추출 (안전한 파싱 사용)
   const filters = parseSearchParams(resolvedSearchParams);
@@ -86,7 +89,7 @@ export default async function StudyPage({ searchParams }: StudyPageProps) {
 
       {/* 콘텐츠 - Suspense로 감싼 카드 그리드 */}
       <Suspense
-        key={(await searchParams).search}
+        key={JSON.stringify({ search, category, page, studyStatus, semester })}
         fallback={<SCStudySkeleton />}
       >
         <SCStudyContent searchParams={searchParams} />

--- a/src/app/api/admin/project/CCAdminProjectParticipantApi.tsx
+++ b/src/app/api/admin/project/CCAdminProjectParticipantApi.tsx
@@ -2,13 +2,14 @@ import { apiClient } from "@/lib/clientIntercept";
 
 // 프로젝트 참가자 승인
 export async function approveAdminProjectParticipant(
-  participantId: number,
+  memberId: number,
+  projectId: number,
   reason = ""
 ) {
   try {
     const res = await apiClient.post(
       `/admin/project/participant/approve`,
-      { participantId, reason },
+      { memberId, projectId, reason },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;
@@ -19,13 +20,14 @@ export async function approveAdminProjectParticipant(
 
 // 프로젝트 참가자 거절
 export async function rejectAdminProjectParticipant(
-  participantId: number,
+  memberId: number,
+  projectId: number,
   reason = ""
 ) {
   try {
     const res = await apiClient.post(
       `/admin/project/participant/reject`,
-      { participantId, reason },
+      { memberId, projectId, reason },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;

--- a/src/app/api/admin/project/CCAdminProjectUpdateApi.tsx
+++ b/src/app/api/admin/project/CCAdminProjectUpdateApi.tsx
@@ -1,0 +1,38 @@
+import { apiClient } from "@/lib/clientIntercept";
+import { AttachedFile } from "@/types/attachedFile";
+import { SemesterType } from "@/types/project";
+
+export interface CreateProjectFormData {
+  title: string;
+  description: string;
+  content: string;
+  category: string;
+  subCategory: string;
+  startDate: string;
+  endDate: string;
+  githubUrl?: string;
+  thumbnailUrl?: string;
+  maxParticipants: number;
+  externalUrl?: { title?: string; url?: string };
+  demoUrl?: string; // 데모/배포 URL
+  semester?: SemesterType;
+  attachments?: AttachedFile[];
+}
+export interface UpdateProjectFormData extends CreateProjectFormData {
+  projectId: number;
+}
+
+// admin 프로젝트 수정
+export async function updateAdminProject(
+  projectId: number,
+  payload: UpdateProjectFormData
+) {
+  try {
+    const res = await apiClient.put(`/admin/project/update`, payload, {
+      headers: { "Content-Type": "application/json" },
+    });
+    return res.data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/app/api/admin/study/CCAdminStudyParticipantApi.tsx
+++ b/src/app/api/admin/study/CCAdminStudyParticipantApi.tsx
@@ -2,13 +2,14 @@ import { apiClient } from "@/lib/clientIntercept";
 
 // 스터디 참가자 승인
 export async function approveAdminStudyParticipant(
-  participantId: number,
+  memberId: number,
+  studyId: number,
   reason = ""
 ) {
   try {
     const res = await apiClient.post(
       `/admin/study/participant/approve`,
-      { participantId, reason },
+      { memberId, studyId, reason },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;
@@ -19,13 +20,14 @@ export async function approveAdminStudyParticipant(
 
 // 스터디 참가자 거절
 export async function rejectAdminStudyParticipant(
-  participantId: number,
+  memberId: number,
+  studyId: number,
   reason = ""
 ) {
   try {
     const res = await apiClient.post(
       `/admin/study/participant/reject`,
-      { participantId, reason },
+      { memberId, studyId, reason },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;

--- a/src/app/api/admin/study/CCAdminStudyUpdateApi.tsx
+++ b/src/app/api/admin/study/CCAdminStudyUpdateApi.tsx
@@ -1,0 +1,17 @@
+import { apiClient } from "@/lib/clientIntercept";
+import { UpdateStudyFormData } from "@/types/study";
+
+// admin 스터디 수정
+export async function updateAdminStudy(
+  studyId: number,
+  payload: UpdateStudyFormData
+) {
+  try {
+    const res = await apiClient.put(`/admin/study/update`, payload, {
+      headers: { "Content-Type": "application/json" },
+    });
+    return res.data;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/app/api/project/CCProjectParticipantApi.tsx
+++ b/src/app/api/project/CCProjectParticipantApi.tsx
@@ -34,11 +34,14 @@ export async function cancelProjectRegister(projectId: number) {
 
 /* 스터디 생성자만 조작 가능 */
 // 참가 신청 승인
-export async function approveProjectParticipant(participantId: number) {
+export async function approveProjectParticipant(
+  memberId: number,
+  projectId: number
+) {
   try {
     const res = await apiClient.post(
       `/project/participant/join/approve`,
-      { participantId },
+      { memberId, projectId },
       {
         headers: {
           "Content-Type": "application/json",
@@ -50,11 +53,14 @@ export async function approveProjectParticipant(participantId: number) {
     throw error;
   }
 }
-export async function rejectProjectParticipant(participantId: number) {
+export async function rejectProjectParticipant(
+  memberId: number,
+  projectId: number
+) {
   try {
     const res = await apiClient.post(
       `/project/participant/join/reject`,
-      { participantId },
+      { memberId, projectId },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;

--- a/src/app/api/study/CCStudyParticipantApi.tsx
+++ b/src/app/api/study/CCStudyParticipantApi.tsx
@@ -34,11 +34,14 @@ export async function cancelStudyRegister(studyId: number) {
 
 /* 스터디 생성자만 조작 가능 */
 // 참가 신청 승인
-export async function approveStudyParticipant(participantId: number) {
+export async function approveStudyParticipant(
+  memberId: number,
+  studyId: number
+) {
   try {
     const res = await apiClient.post(
       `/study/participant/join/approve`,
-      { participantId },
+      { memberId, studyId },
       {
         headers: {
           "Content-Type": "application/json",
@@ -50,11 +53,14 @@ export async function approveStudyParticipant(participantId: number) {
     throw error;
   }
 }
-export async function rejectStudyParticipant(participantId: number) {
+export async function rejectStudyParticipant(
+  memberId: number,
+  studyId: number
+) {
   try {
     const res = await apiClient.post(
       `/study/participant/join/reject`,
-      { participantId },
+      { memberId, studyId },
       { headers: { "Content-Type": "application/json" } }
     );
     return res.data;

--- a/src/components/admin/schedule/SCAdminScheduleInfo.tsx
+++ b/src/components/admin/schedule/SCAdminScheduleInfo.tsx
@@ -5,7 +5,11 @@ import LocationSVG from "/public/icons/location.svg";
 import TimeSVG from "/public/icons/time.svg";
 import { ScheduleInfo } from "@/types/schedule";
 import { getTypeColor, getTypeLabel } from "@/utils/scheduleUtils";
-import { formatDate, formatTime } from "@/utils/formatDateUtil";
+import {
+  formatDate,
+  formatDateRange,
+  formatTime,
+} from "@/utils/formatDateUtil";
 import { MessageSquareText } from "lucide-react";
 import CCEditDeleteButtonsWrapper from "@/components/admin/schedule/CCEditDeleteButtonsWrapper";
 import { getSchedules } from "@/app/api/schedule/SCscheduleApi";
@@ -51,7 +55,11 @@ export default async function SCAdminScheduleInfo({
                   <div className="space-y-2 text-sm text-gray-600">
                     <div className="flex flex-row items-center">
                       <ScheduleSVG className="w-4 mr-2 stroke-gray-700" />
-                      {formatDate(schedule.startedAt, "dot")}
+                      {formatDateRange(
+                        schedule.startedAt,
+                        schedule.endedAt,
+                        "dot"
+                      )}
                     </div>
                     <div className="flex flex-row items-center">
                       <TimeSVG className="mr-2" />

--- a/src/components/admin/schedule/SCAdminScheduleRequestList.tsx
+++ b/src/components/admin/schedule/SCAdminScheduleRequestList.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/actions/admin/schedule/AdminScheduleRequestServerAction";
 import { getPendingSchedules } from "@/app/api/schedule/SCAdminScheduleApi";
 import RequestActionButtons from "@/components/ui/requestActionButtons";
-import { formatDate, formatTime } from "@/utils/formatDateUtil";
+import { formatDateRange, formatTime } from "@/utils/formatDateUtil";
 import {
   CheckCircle,
   Clock,
@@ -56,7 +56,13 @@ export default async function CCAdminScheduleRequestList() {
                     </div>
                     <div className="flex items-center gap-1">
                       <Calendar className="w-3 h-3" />
-                      <span>{formatDate(reservation.startedAt, "short")}</span>
+                      <span>
+                        {formatDateRange(
+                          reservation.startedAt,
+                          reservation.endedAt,
+                          "dot"
+                        )}
+                      </span>
                     </div>
                     <div className="flex items-center gap-1">
                       <Clock className="w-3 h-3" />

--- a/src/components/blog/SCBlogCardList.tsx
+++ b/src/components/blog/SCBlogCardList.tsx
@@ -1,9 +1,10 @@
 "server-only";
-
+import Image from "next/image";
 import Link from "next/link";
 import { BlogDataType } from "@/types/blog";
 import { formatDate } from "@/utils/formatDateUtil";
 import { getCategoryColor } from "@/utils/badgeUtils";
+import LogoSVG from "/public/icons/logo.svg";
 
 interface SCBlogCardListProps {
   blogs: BlogDataType[];
@@ -56,10 +57,17 @@ export default function BlogCardList({ blogs }: SCBlogCardListProps) {
 
             {/* 작성자 */}
             <div className="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-gray-700">
-              <div className="w-7 h-7 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center">
-                <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">
-                  {blog.blogCreatorName?.charAt(0).toUpperCase()}
-                </span>
+              <div className="relative w-7 h-7 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                {blog.blogCreatorProfileImageUrl ? (
+                  <Image
+                    src={blog.blogCreatorProfileImageUrl}
+                    alt={`${blog.blogCreatorName} 프로필`}
+                    fill
+                    className="object-cover"
+                  />
+                ) : (
+                  <LogoSVG className="w-7 h-7 text-gray-400" />
+                )}
               </div>
               <span className="text-sm text-gray-700 font-medium dark:text-gray-300">
                 {blog.blogCreatorName}

--- a/src/components/detail/CCKebabMenu.tsx
+++ b/src/components/detail/CCKebabMenu.tsx
@@ -61,21 +61,20 @@ export default function KebabMenu({
           throw new Error("알 수 없는 도메인입니다.");
       }
 
-      //  admin 여부에 따라 분기
+      // admin 여부에 따라 분기
       if (isAdmin) {
-        if (isAdmin) {
-          if (currentUrl.startsWith("study")) {
-            router.push("/admin/study?tab=study");
-          } else if (currentUrl.startsWith("project")) {
-            router.push("/admin/study?tab=project&view=list");
-          } else if (currentUrl.startsWith("blog")) {
-            router.push("/admin/blog");
-          }
+        if (currentUrl.startsWith("study")) {
+          router.push("/admin/study?tab=study");
+        } else if (currentUrl.startsWith("project")) {
+          router.push("/admin/study?tab=project&view=list");
+        } else if (currentUrl.startsWith("blog")) {
+          router.push("/admin/blog");
         } else {
-          router.push(`/${currentUrl}`);
+          router.push("/admin");
         }
+      } else {
+        router.push(`/${currentUrl}`);
       }
-      router.refresh();
     } catch (error) {
       setAlertOpen(true); //  실패 시 알림
       throw error;

--- a/src/components/profile/SCTodaySchedule.tsx
+++ b/src/components/profile/SCTodaySchedule.tsx
@@ -23,7 +23,7 @@ export default async function SCTodaySchedule() {
             <div className="space-y-3">
               {profile.todaySchedules.map((schedule: ScheduleInProfileData) => (
                 <div
-                  key={schedule.scheduleId}
+                  key={schedule.id}
                   className="card-list bg-gray-50 flex items-center justify-between p-3 group cursor-default"
                 >
                   <div>

--- a/src/components/project/CCProjectFilter.tsx
+++ b/src/components/project/CCProjectFilter.tsx
@@ -33,7 +33,6 @@ export default function CCProjectFilter({
   const router = useRouter();
   const searchParams = useSearchParams();
   const view = searchParams.get("view");
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [isPending, startTransition] = useTransition();
 
   const [showSemesterDropdown, setShowSemesterDropdown] = useState(false);
@@ -148,6 +147,7 @@ export default function CCProjectFilter({
                 setShowSubCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span className="text-gray-700 truncate pr-1 dark:text-gray-200">
                 {SEMESTER_LABELS[projectCurrentFilters.semester]}
@@ -198,6 +198,7 @@ export default function CCProjectFilter({
                 setShowSubCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span className="text-gray-700 truncate pr-1 dark:text-gray-200">
                 {CATEGORY_LABELS[projectCurrentFilters.category]}
@@ -248,6 +249,7 @@ export default function CCProjectFilter({
                 setShowCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span className="text-gray-700 truncate pr-1 dark:text-gray-200">
                 {projectCurrentFilters.subCategory
@@ -299,7 +301,9 @@ export default function CCProjectFilter({
                   : "cursor-pointer border-gray-300 bg-white hover:border-cert-red hover:text-cert-black hover:bg-white focus:border-cert-red focus:ring-2 focus:ring-cert-red/20 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
               )}
               disabled={
-                (isAdmin && view === "pending") || (isAdmin && view === "end")
+                (isAdmin && view === "pending") ||
+                (isAdmin && view === "end") ||
+                isPending
               }
               onClick={() => {
                 if (

--- a/src/components/schedule/CCScheduleFormModal.tsx
+++ b/src/components/schedule/CCScheduleFormModal.tsx
@@ -97,7 +97,7 @@ export default function CCScheduleFormModal({
     if (!typeValue || !isValidForm) return;
 
     const start = new Date(`${date}T${selectedStartTime}:00+09:00`);
-    let end = new Date(`${date}T${selectedEndTime}:00+09:00`);
+    const end = new Date(`${date}T${selectedEndTime}:00+09:00`);
 
     let durationHours = 0;
 

--- a/src/components/schedule/CCScheduleFormModal.tsx
+++ b/src/components/schedule/CCScheduleFormModal.tsx
@@ -23,6 +23,7 @@ import {
   createAdminSchedule,
   deleteAdminSchedule,
 } from "@/app/api/schedule/CCAdminScheduleApi";
+import AlertModal from "@/components/ui/defaultAlertModal";
 
 interface ScheduleFormModalProps {
   closeModal: () => void;
@@ -65,6 +66,9 @@ export default function CCScheduleFormModal({
   const [date, setDate] = useState("");
   const [description, setDescription] = useState("");
   const today = new Date().toISOString().split("T")[0];
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
+  const [alertType, setAlertType] = useState<"success" | "warning">("warning");
 
   useEffect(() => {
     if (!schedule) return;
@@ -92,8 +96,38 @@ export default function CCScheduleFormModal({
     const typeValue = labelToType(selectedType);
     if (!typeValue || !isValidForm) return;
 
-    const startedAt = toOffset(`${date}T${selectedStartTime}:00`);
-    const endedAt = toOffset(`${date}T${selectedEndTime}:00`);
+    const start = new Date(`${date}T${selectedStartTime}:00+09:00`);
+    let end = new Date(`${date}T${selectedEndTime}:00+09:00`);
+
+    let durationHours = 0;
+
+    if (end < start) {
+      // 자정을 넘긴 경우 -> 다음날로 보정
+      end.setDate(end.getDate() + 1);
+      durationHours = (end.getTime() - start.getTime()) / 3_600_000;
+
+      // 23시간 초과 차단
+      if (durationHours > 23) {
+        setAlertMessage("자정을 넘기는 예약은 최대 23시간까지만 허용됩니다.");
+        setAlertType("warning");
+        setAlertOpen(true);
+        return;
+      }
+    } else {
+      // 같은 날 케이스 -> 그냥 차이만 구함
+      durationHours = (end.getTime() - start.getTime()) / 3_600_000;
+    }
+
+    // 동일 시간 체크
+    if (durationHours <= 0) {
+      setAlertMessage("시작시간과 종료시간은 같을 수 없습니다.");
+      setAlertType("warning");
+      setAlertOpen(true);
+      return;
+    }
+
+    const startedAt = toOffset(start.toISOString());
+    const endedAt = toOffset(end.toISOString());
 
     try {
       if (isAdmin) {
@@ -113,7 +147,6 @@ export default function CCScheduleFormModal({
         if (schedule?.scheduleId) {
           await deleteSchedule(schedule.scheduleId);
         }
-
         const userData: ScheduleCreateRequest = {
           title,
           description,
@@ -127,219 +160,228 @@ export default function CCScheduleFormModal({
       router.refresh();
       closeModal();
     } catch (err) {
-      console.error("스케줄 저장 실패", err);
+      throw err;
     }
   };
 
   return (
-    <div
-      ref={modalRef}
-      className="fixed inset-0 bg-cert-black/50 flex justify-center items-center z-30"
-    >
-      <div className="rounded-lg border shadow-sm w-96 relative animate-pop-in dark-default">
-        <div className="flex flex-col space-y-1.5 p-6 text-center pb-6">
-          <div className="flex flex-col space-y-1.5 text-center sm:text-left">
-            <button
-              onClick={closeModal}
-              className="absolute top-4 right-4 text-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 flex items-center justify-center"
-            >
-              <X />
-            </button>
-            <p className="text-gray-900 dark:text-gray-200">
-              {isAdmin ? "새 일정" : "동아리방 예약"}
-            </p>
-            <p className="text-gray-500 text-sm dark:text-gray-400">
-              {isAdmin
-                ? "새 일정 정보를 입력해주세요."
-                : "동아리방 예약 정보를 입력해주세요."}
-            </p>
-          </div>
-
-          <div className="space-y-4 text-left my-6">
-            <div>
-              <p className="text-sm mb-1.5 dark:text-gray-200">활동명</p>
-              <input
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={isAdmin ? "예: 9월 정기회의" : "예: 해킹 스터디"}
-                className="text-sm required flex h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
-                required
-              />
+    <>
+      <div
+        ref={modalRef}
+        className="fixed inset-0 bg-cert-black/50 flex justify-center items-center z-30"
+      >
+        <div className="rounded-lg border shadow-sm w-96 relative animate-pop-in dark-default">
+          <div className="flex flex-col space-y-1.5 p-6 text-center pb-6">
+            <div className="flex flex-col space-y-1.5 text-center sm:text-left">
+              <button
+                onClick={closeModal}
+                className="absolute top-4 right-4 text-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 flex items-center justify-center"
+              >
+                <X />
+              </button>
+              <p className="text-gray-900 dark:text-gray-200">
+                {isAdmin ? "새 일정" : "동아리방 예약"}
+              </p>
+              <p className="text-gray-500 text-sm dark:text-gray-400">
+                {isAdmin
+                  ? "새 일정 정보를 입력해주세요."
+                  : "동아리방 예약 정보를 입력해주세요."}
+              </p>
             </div>
 
-            {isAdmin ? (
+            <div className="space-y-4 text-left my-6">
               <div>
-                <p className="text-sm mb-1.5 dark:text-gray-200">장소</p>
+                <p className="text-sm mb-1.5 dark:text-gray-200">활동명</p>
                 <input
-                  value={place}
-                  onChange={(e) => setPlace(e.target.value)}
-                  placeholder="예: 장보고관"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={isAdmin ? "예: 9월 정기회의" : "예: 해킹 스터디"}
+                  className="text-sm required flex h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+                  required
+                />
+              </div>
+
+              {isAdmin ? (
+                <div>
+                  <p className="text-sm mb-1.5 dark:text-gray-200">장소</p>
+                  <input
+                    value={place}
+                    onChange={(e) => setPlace(e.target.value)}
+                    placeholder="예: 장보고관"
+                    className="text-sm flex h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+                    required
+                  />
+                </div>
+              ) : (
+                ""
+              )}
+
+              <div>
+                <p className="text-sm mb-1.5 dark:text-gray-200">설명</p>
+                <input
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder={
+                    isAdmin
+                      ? "예: 9월 정기모임을 위한 행사입니다."
+                      : "예: 해킹 스터디를 위한 동아리방 예약입니다."
+                  }
                   className="text-sm flex h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
                   required
                 />
               </div>
-            ) : (
-              ""
-            )}
 
-            <div>
-              <p className="text-sm mb-1.5 dark:text-gray-200">설명</p>
-              <input
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={
-                  isAdmin
-                    ? "예: 9월 정기모임을 위한 행사입니다."
-                    : "예: 해킹 스터디를 위한 동아리방 예약입니다."
-                }
-                className="text-sm flex h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
-                required
-              />
+              {/* 날짜 + 활동 유형 */}
+              <div className="grid grid-cols-2 gap-4 z-10">
+                <div>
+                  <p className="text-sm mb-1.5 dark:text-gray-200">이용 날짜</p>
+                  <input
+                    type="date"
+                    value={date}
+                    min={today}
+                    onChange={(e) => setDate(e.target.value)}
+                    className="text-sm h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 cursor-pointer justify-between"
+                    required
+                  />
+                </div>
+
+                <div className="relative z-10" ref={typeDropdownRef}>
+                  <p className="text-sm mb-1.5 dark:text-gray-200">활동 유형</p>
+                  <DefaultButton
+                    variant="outline"
+                    size="default"
+                    className={cn(
+                      "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
+                      "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
+                      "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
+                      "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
+                    )}
+                    onClick={toggleDropdown}
+                  >
+                    <span className="text-gray-700 dark:text-gray-200 truncate">
+                      {selectedType}
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
+                        isTypeDropdownOpen ? "rotate-180" : ""
+                      }`}
+                    />
+                  </DefaultButton>
+                  {isTypeDropdownOpen && (
+                    <div className="absolute border border-gray-300 bg-white w-full rounded-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200">
+                      {TYPE_LABELS.map((label) => (
+                        <button
+                          key={label}
+                          onClick={() => handleType(label)}
+                          className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* 시작/종료 시간 */}
+              <div className="grid grid-cols-2 gap-4 z-10">
+                <div className="relative" ref={startTimeDropdownRef}>
+                  <p className="text-sm mb-1.5 dark:text-gray-200">시작 시간</p>
+                  <DefaultButton
+                    variant="outline"
+                    size="default"
+                    className={cn(
+                      "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
+                      "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
+                      "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
+                      "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
+                    )}
+                    onClick={toggleStartTimeDropdown}
+                  >
+                    <span className="text-gray-700 dark:text-gray-200 truncate">
+                      {selectedStartTime}
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
+                        isStartTimeDropdownOpen ? "rotate-180" : ""
+                      }`}
+                    />
+                  </DefaultButton>
+                  {isStartTimeDropdownOpen && (
+                    <div className="absolute top-full left-0 right-0 z-10 bg-white border border-gray-300 shadow-md max-h-48 overflow-y-auto rounded-md dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200">
+                      {timeOptions.map((time) => (
+                        <button
+                          key={time}
+                          onClick={() => handleStartTime(time)}
+                          className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
+                        >
+                          {time}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div className="relative" ref={endTimeDropdownRef}>
+                  <p className="text-sm mb-1.5 dark:text-gray-200">종료 시간</p>
+                  <DefaultButton
+                    variant="outline"
+                    size="default"
+                    className={cn(
+                      "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
+                      "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
+                      "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
+                      "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
+                    )}
+                    onClick={toggleEndTimeDropdown}
+                  >
+                    <span className="text-gray-700 dark:text-gray-200 truncate">
+                      {selectedEndTime}
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
+                        isEndTimeDropdownOpen ? "rotate-180" : ""
+                      }`}
+                    />
+                  </DefaultButton>
+                  {isEndTimeDropdownOpen && (
+                    <div className="absolute top-full left-0 right-0 z-10 bg-white border border-gray-300 shadow-md max-h-48 overflow-y-auto rounded-md dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200">
+                      {timeOptions.map((time) => (
+                        <button
+                          key={time}
+                          onClick={() => handleEndTime(time)}
+                          className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
+                        >
+                          {time}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+              {timeError && (
+                <p className="text-cert-red text-sm">⚠️ {timeError}</p>
+              )}
             </div>
 
-            {/* 날짜 + 활동 유형 */}
-            <div className="grid grid-cols-2 gap-4 z-10">
-              <div>
-                <p className="text-sm mb-1.5 dark:text-gray-200">이용 날짜</p>
-                <input
-                  type="date"
-                  value={date}
-                  min={today}
-                  onChange={(e) => setDate(e.target.value)}
-                  className="text-sm h-10 w-full rounded-md border px-3 py-2 bg-white text-gray-900 border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 cursor-pointer justify-between"
-                  required
-                />
-              </div>
-
-              <div className="relative z-10" ref={typeDropdownRef}>
-                <p className="text-sm mb-1.5 dark:text-gray-200">활동 유형</p>
-                <DefaultButton
-                  variant="outline"
-                  size="default"
-                  className={cn(
-                    "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
-                    "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
-                    "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
-                    "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
-                  )}
-                  onClick={toggleDropdown}
-                >
-                  <span className="text-gray-700 dark:text-gray-200 truncate">
-                    {selectedType}
-                  </span>
-                  <ChevronDown
-                    className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
-                      isTypeDropdownOpen ? "rotate-180" : ""
-                    }`}
-                  />
-                </DefaultButton>
-                {isTypeDropdownOpen && (
-                  <div className="absolute border border-gray-300 bg-white w-full rounded-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200">
-                    {TYPE_LABELS.map((label) => (
-                      <button
-                        key={label}
-                        onClick={() => handleType(label)}
-                        className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
-                      >
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* 시작/종료 시간 */}
-            <div className="grid grid-cols-2 gap-4 z-10">
-              <div className="relative" ref={startTimeDropdownRef}>
-                <p className="text-sm mb-1.5 dark:text-gray-200">시작 시간</p>
-                <DefaultButton
-                  variant="outline"
-                  size="default"
-                  className={cn(
-                    "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
-                    "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
-                    "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
-                    "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
-                  )}
-                  onClick={toggleStartTimeDropdown}
-                >
-                  <span className="text-gray-700 dark:text-gray-200 truncate">
-                    {selectedStartTime}
-                  </span>
-                  <ChevronDown
-                    className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
-                      isStartTimeDropdownOpen ? "rotate-180" : ""
-                    }`}
-                  />
-                </DefaultButton>
-                {isStartTimeDropdownOpen && (
-                  <div className="absolute top-full left-0 right-0 z-10 bg-white border border-gray-300 shadow-md max-h-48 overflow-y-auto rounded-md dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200">
-                    {timeOptions.map((time) => (
-                      <button
-                        key={time}
-                        onClick={() => handleStartTime(time)}
-                        className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
-                      >
-                        {time}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="relative" ref={endTimeDropdownRef}>
-                <p className="text-sm mb-1.5 dark:text-gray-200">종료 시간</p>
-                <DefaultButton
-                  variant="outline"
-                  size="default"
-                  className={cn(
-                    "w-full justify-between text-left font-normal transition-all duration-200 cursor-pointer",
-                    "bg-white border-gray-300 hover:border-cert-red hover:bg-white hover:text-cert-black",
-                    "focus:border-cert-red focus:ring-2 focus:ring-cert-red/20",
-                    "dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-800"
-                  )}
-                  onClick={toggleEndTimeDropdown}
-                >
-                  <span className="text-gray-700 dark:text-gray-200 truncate">
-                    {selectedEndTime}
-                  </span>
-                  <ChevronDown
-                    className={`h-4 w-4 transition-transform duration-300 text-gray-400 ${
-                      isEndTimeDropdownOpen ? "rotate-180" : ""
-                    }`}
-                  />
-                </DefaultButton>
-                {isEndTimeDropdownOpen && (
-                  <div className="absolute top-full left-0 right-0 z-10 bg-white border border-gray-300 shadow-md max-h-48 overflow-y-auto rounded-md dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200">
-                    {timeOptions.map((time) => (
-                      <button
-                        key={time}
-                        onClick={() => handleEndTime(time)}
-                        className="text-sm items-center flex h-10 w-full rounded-md px-3 py-2 text-gray-900 dark:text-gray-200 hover:bg-cert-red hover:text-white dark:hover:bg-cert-red duration-100 cursor-pointer"
-                      >
-                        {time}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-            {timeError && (
-              <p className="text-cert-red text-sm">⚠️ {timeError}</p>
-            )}
+            <DefaultButton
+              type="submit"
+              className="w-full mt-2"
+              disabled={!isValidForm}
+              onClick={handleSubmit}
+            >
+              {isAdmin ? "추가" : "신청"}
+            </DefaultButton>
           </div>
-
-          <DefaultButton
-            type="submit"
-            className="w-full mt-2"
-            disabled={!isValidForm}
-            onClick={handleSubmit}
-          >
-            {isAdmin ? "추가" : "신청"}
-          </DefaultButton>
         </div>
       </div>
-    </div>
+      <AlertModal
+        isOpen={alertOpen}
+        message={alertMessage}
+        type={alertType}
+        duration={2500}
+        onClose={() => setAlertOpen(false)}
+      />
+    </>
   );
 }

--- a/src/components/schedule/SCScheduleInfo.tsx
+++ b/src/components/schedule/SCScheduleInfo.tsx
@@ -5,7 +5,11 @@ import LocationSVG from "/public/icons/location.svg";
 import TimeSVG from "/public/icons/time.svg";
 import { ScheduleInfo } from "@/types/schedule";
 import { getTypeColor, getTypeLabel } from "@/utils/scheduleUtils";
-import { formatDate, formatTime } from "@/utils/formatDateUtil";
+import {
+  formatDate,
+  formatDateRange,
+  formatTime,
+} from "@/utils/formatDateUtil";
 import { MessageSquareText } from "lucide-react";
 import { getSchedules } from "@/app/api/schedule/SCscheduleApi";
 
@@ -51,7 +55,11 @@ export default async function SCScheduleInfo({
                   <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
                     <div className="flex flex-row items-center">
                       <ScheduleSVG className="w-4 mr-2 stroke-gray-700 dark:stroke-gray-300" />
-                      {formatDate(schedule.startedAt, "dot")}
+                      {formatDateRange(
+                        schedule.startedAt,
+                        schedule.endedAt,
+                        "dot"
+                      )}
                     </div>
                     <div className="flex flex-row items-center">
                       <TimeSVG className="mr-2" />

--- a/src/components/schedule/SCScheduleList.tsx
+++ b/src/components/schedule/SCScheduleList.tsx
@@ -5,7 +5,7 @@ import LocationSVG from "/public/icons/location.svg";
 import TimeSVG from "/public/icons/time.svg";
 import { getTypeColor, getTypeLabel } from "@/utils/scheduleUtils";
 import { ScheduleInfo } from "@/types/schedule";
-import { formatDate, formatTime } from "@/utils/formatDateUtil";
+import { formatDateRange, formatTime } from "@/utils/formatDateUtil";
 import { MessageSquareText } from "lucide-react";
 import { getSchedules } from "@/app/api/schedule/SCscheduleApi";
 
@@ -51,8 +51,12 @@ export default async function SCScheduleList({
                     </p>
                     <div className="space-y-2 text-sm text-gray-600  dark:text-gray-300">
                       <div className="flex items-center">
-                        <ScheduleSVG className="w-4 mr-2 stroke-gray-600  dark:stroke-gray-300" />
-                        {formatDate(schedule.startedAt, "dot")}
+                        <ScheduleSVG className="w-4 mr-2 stroke-gray-600 dark:stroke-gray-300" />
+                        {formatDateRange(
+                          schedule.startedAt,
+                          schedule.endedAt,
+                          "dot"
+                        )}
                       </div>
                       <div className="flex items-center">
                         <TimeSVG className="mr-2" />

--- a/src/components/schedule/SCScheduleRequestList.tsx
+++ b/src/components/schedule/SCScheduleRequestList.tsx
@@ -12,12 +12,13 @@ import {
 } from "@/utils/scheduleUtils";
 import CCDeleteButton from "@/components/admin/schedule/CCDeleteButton";
 import { ScheduleInfo } from "@/types/schedule";
-import { formatDate, formatTime } from "@/utils/formatDateUtil";
+import { formatDateRange, formatTime } from "@/utils/formatDateUtil";
 import { getMySchedules } from "@/app/api/schedule/SCscheduleApi";
 
 export default async function SCScheduleRequestList() {
   const requests: ScheduleInfo[] = await getMySchedules();
   const pendingRequests = requests.filter((r) => r.status === "PENDING");
+
   return (
     <div className="mt-6 p-6 rounded-lg border shadow-sm h-min dark-default">
       <p className="text-lg font-semibold mb-4">예약 신청 현황</p>
@@ -30,7 +31,7 @@ export default async function SCScheduleRequestList() {
         ) : (
           pendingRequests.map((request) => (
             <div key={request.scheduleId} className="text-sm text-gray-700">
-              <div className="relative flex items-start border p-3 rounded-lg border-gray-200 bg-gray-50 gap-3 dark:bg-gray-700 dark:border-gray-600">
+              <div className="relative flex items-start border p-3 rounded-lg border-gray-200 bg-gray-50 dark:bg-gray-700 dark:border-gray-600">
                 <div className="flex-1 min-w-0">
                   <p className="text-md font-semibold text-gray-700 mb-3 dark:text-gray-200">
                     {request.title}
@@ -38,7 +39,11 @@ export default async function SCScheduleRequestList() {
                   <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
                     <div className="flex flex-row items-center">
                       <ScheduleSVG className="w-4 mr-2 stroke-gray-700 dark:stroke-gray-300" />
-                      {formatDate(request.startedAt, "dot")}
+                      {formatDateRange(
+                        request.startedAt,
+                        request.endedAt,
+                        "dot"
+                      )}
                     </div>
                     <div className="flex flex-row items-center">
                       <TimeSVG className="mr-2" />
@@ -59,16 +64,16 @@ export default async function SCScheduleRequestList() {
                   </div>
                 </div>
 
-                <div>
+                <div className="absolute right-3 top-3 flex flex-row items-center gap-2">
                   <div
-                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold shrink-0 whitespace-nowrap ${getStatusColor(
+                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold whitespace-nowrap ${getStatusColor(
                       request.status
                     )}`}
                   >
                     {getStatusLabel(request.status)}
                   </div>
                   <div
-                    className={`ml-2 inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors shrink-0 whitespace-nowrap ${getTypeColor(
+                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors whitespace-nowrap ${getTypeColor(
                       request.type
                     )}`}
                   >
@@ -76,7 +81,6 @@ export default async function SCScheduleRequestList() {
                   </div>
                 </div>
                 <div className="absolute right-3 bottom-3">
-                  {/* <CCDeleteButton schedule={request} onRemove={onRemove} /> */}
                   <CCDeleteButton schedule={request} />
                 </div>
               </div>

--- a/src/components/schedule/SCScheduleSkeleton.tsx
+++ b/src/components/schedule/SCScheduleSkeleton.tsx
@@ -1,0 +1,85 @@
+"server-only";
+
+export default function SCScheduleSkeleton() {
+  return (
+    <div className="min-h-screen animate-pulse">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="md:col-span-2">
+            <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+              <div className="flex items-center justify-between mb-4">
+                <div className="h-6 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                <div className="flex gap-2">
+                  <div className="h-8 w-8 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                  <div className="h-8 w-8 bg-gray-200 dark:bg-gray-700 rounded"></div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-7 gap-1 mb-2">
+                {Array.from({ length: 7 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-4 bg-gray-200 dark:bg-gray-700 rounded"
+                  ></div>
+                ))}
+              </div>
+
+              <div className="grid grid-cols-7 gap-1">
+                {Array.from({ length: 35 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-20 bg-gray-200 dark:bg-gray-700 rounded"
+                  ></div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* 사이드 영역 */}
+          <div className="space-y-6">
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+              <div className="h-6 w-24 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
+              <div className="h-10 w-full bg-gray-200 dark:bg-gray-700 rounded"></div>
+            </div>
+
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+              <div className="h-6 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-20 bg-gray-200 dark:bg-gray-700 rounded"
+                  ></div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+              <div className="h-6 w-32 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
+              <div className="space-y-3">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-16 bg-gray-200 dark:bg-gray-700 rounded"
+                  ></div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="my-12">
+          <div className="h-8 w-40 bg-gray-200 dark:bg-gray-700 rounded mb-6"></div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-40 bg-gray-200 dark:bg-gray-700 rounded-lg"
+              ></div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/study/CCStudyFilter.tsx
+++ b/src/components/study/CCStudyFilter.tsx
@@ -178,11 +178,6 @@ export default function CCStudyFilter({
             onChange={handleSearchChange}
             className="pl-10 w-full"
           />
-          {isPending && (
-            <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-red-500" />
-            </div>
-          )}
         </div>
 
         {/* 필터 버튼들 */}
@@ -207,6 +202,7 @@ export default function CCStudyFilter({
                 setShowSubCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span className="text-gray-700 truncate pr-1 dark:text-gray-200">
                 {SEMESTER_LABELS[studyCurrentFilters.semester]}
@@ -257,6 +253,7 @@ export default function CCStudyFilter({
                 setShowSubCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span className="text-gray-700 truncate pr-1 dark:text-gray-200">
                 {CATEGORY_LABELS[studyCurrentFilters.category]}
@@ -307,6 +304,7 @@ export default function CCStudyFilter({
                 setShowCategoryDropdown(false);
                 setShowStatusDropdown(false);
               }}
+              disabled={isPending}
             >
               <span
                 className="block w-20 truncate pr-1 text-gray-700 dark:text-gray-200"
@@ -358,7 +356,9 @@ export default function CCStudyFilter({
               variant="outline"
               size="default"
               disabled={
-                (isAdmin && view === "pending") || (isAdmin && view === "end")
+                (isAdmin && view === "pending") ||
+                (isAdmin && view === "end") ||
+                isPending
               }
               className={cn(
                 "w-full justify-between text-left font-normal transition-all duration-200",

--- a/src/components/ui/CCParticipantActionButtons.tsx
+++ b/src/components/ui/CCParticipantActionButtons.tsx
@@ -19,9 +19,11 @@ import {
 } from "@/app/api/admin/project/CCAdminProjectParticipantApi";
 
 export default function CCParticipantActionButtons({
-  participantId,
+  memberId,
+  dataId,
 }: {
-  participantId: number;
+  memberId: number;
+  dataId: number;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -36,15 +38,15 @@ export default function CCParticipantActionButtons({
       if (isAdmin) {
         const tab = searchParams.get("tab");
         if (tab === "study") {
-          await approveAdminStudyParticipant(participantId);
+          await approveAdminStudyParticipant(memberId, dataId);
         } else {
-          await approveAdminProjectParticipant(participantId);
+          await approveAdminProjectParticipant(memberId, dataId);
         }
       } else {
         if (pageType === "study") {
-          await approveStudyParticipant(participantId);
+          await approveStudyParticipant(memberId, dataId);
         } else {
-          await approveProjectParticipant(participantId);
+          await approveProjectParticipant(memberId, dataId);
         }
       }
       router.refresh();
@@ -58,15 +60,15 @@ export default function CCParticipantActionButtons({
       if (isAdmin) {
         const tab = searchParams.get("tab");
         if (tab === "study") {
-          await rejectAdminStudyParticipant(participantId);
+          await rejectAdminStudyParticipant(memberId, dataId);
         } else {
-          await rejectAdminProjectParticipant(participantId);
+          await rejectAdminProjectParticipant(memberId, dataId);
         }
       } else {
         if (pageType === "study") {
-          await rejectStudyParticipant(participantId);
+          await rejectStudyParticipant(memberId, dataId);
         } else {
-          await rejectProjectParticipant(participantId);
+          await rejectProjectParticipant(memberId, dataId);
         }
       }
       router.refresh();

--- a/src/components/write/CCEditForm.tsx
+++ b/src/components/write/CCEditForm.tsx
@@ -377,7 +377,7 @@ export default function EditForm({
   };
 
   const handleCancel = () => {
-    if (isAdmin) {
+    if (from === "admin" || isAdmin) {
       if (type === "study" || type === "project") {
         router.push(`/admin/study/${dataId}?tab=${type}`);
       } else {

--- a/src/components/write/CCEditForm.tsx
+++ b/src/components/write/CCEditForm.tsx
@@ -114,8 +114,12 @@ export default function EditForm({
       setDateError("");
     }
   }, []);
-  const startWeek = getNextMonday();
-  const endWeek = getNextSunday();
+  const [startWeek, setStartWeek] = useState("");
+  const [endWeek, setEndWeek] = useState("");
+  useEffect(() => {
+    setStartWeek(getNextMonday());
+    setEndWeek(getNextSunday());
+  }, []);
 
   useEffect(() => {
     validateDates(startDate, endDate);

--- a/src/components/write/CCFileUpload.tsx
+++ b/src/components/write/CCFileUpload.tsx
@@ -50,7 +50,7 @@ export default function FileUpload({
           onChange={handleFileUpload}
           className="hidden"
           id="file-upload"
-          accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.jpg,.jpeg,.png,.gif,.hwp,.hwpx"
+          accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.jpg,.jpeg,.png,.gif,.hwp,.hwpx, .csv"
         />
         <label
           htmlFor="file-upload"

--- a/src/components/write/CCFileUpload.tsx
+++ b/src/components/write/CCFileUpload.tsx
@@ -40,7 +40,8 @@ export default function FileUpload({
     <div className="space-y-4">
       <div
         className={cn(
-          "border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-cert-red transition-colors  dark:border-gray-600",
+          "border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-cert-red transition-colors",
+          "dark:border-gray-600 dark:hover:border-cert-red dark:bg-gray-800/40",
           className
         )}
       >
@@ -50,17 +51,17 @@ export default function FileUpload({
           onChange={handleFileUpload}
           className="hidden"
           id="file-upload"
-          accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.jpg,.jpeg,.png,.gif,.hwp,.hwpx, .csv"
+          accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.jpg,.jpeg,.png,.gif,.hwp,.hwpx,.csv"
         />
         <label
           htmlFor="file-upload"
           className="cursor-pointer flex flex-col items-center gap-2"
         >
-          <Upload className="w-8 h-8 text-gray-400" />
-          <span className="text-sm text-gray-600 dark:text-gray-400 ">
+          <Upload className="w-8 h-8 text-gray-400 dark:text-gray-300" />
+          <span className="text-sm text-gray-600 dark:text-gray-200">
             파일을 드래그하거나 클릭하여 업로드
           </span>
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
             최대 10MB, HWP, PDF, DOC, XLS, PPT, 이미지 파일
           </span>
         </label>
@@ -68,18 +69,21 @@ export default function FileUpload({
 
       {attachments.length > 0 && (
         <div className="space-y-2">
-          <h4 className="text-sm font-medium text-gray-700">
+          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-200">
             첨부파일 ({attachments.length})
           </h4>
           {attachments.map((file) => (
             <div
               key={getFileKey(file)}
-              className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
+              className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg 
+                   dark:bg-gray-700 dark:border dark:border-gray-700"
             >
               <span className="text-lg">{getFileIcon(file.type)}</span>
               <div className="flex-1">
-                <p className="text-sm font-medium text-gray-900">{file.name}</p>
-                <p className="text-xs text-gray-500">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {file.name}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   {formatFileSize(file.size)}
                 </p>
               </div>
@@ -88,7 +92,8 @@ export default function FileUpload({
                 variant="outline"
                 size="sm"
                 onClick={() => handleRemoveFile(file.name)}
-                className="text-cert-red hover:bg-red-50 hover:text-cert-red"
+                className="text-cert-red hover:bg-red-50 hover:text-cert-red 
+                     dark:hover:bg-red-900/30 dark:bg-gray-600"
               >
                 <Trash2 className="w-4 h-4" />
               </DefaultButton>

--- a/src/components/write/CCWriteForm.tsx
+++ b/src/components/write/CCWriteForm.tsx
@@ -29,6 +29,7 @@ import {
 import { BoardCategoryType, categoryMappingToEN } from "@/types/board";
 import { createProject } from "@/app/api/project/CCProjectApi";
 import { getNextMonday, getNextSunday } from "@/utils/dateUtils";
+import { AxiosError } from "axios";
 
 interface WriteFormProps {
   type: NewPageCategoryType;
@@ -77,6 +78,7 @@ export default function WriteForm({ type, initialReferences }: WriteFormProps) {
 
   const [thumbnailUrl, setThumbnailUrl] = useState<string>("");
   const [dateError, setDateError] = useState<string>("");
+  const [alertMessage, setAlertMessage] = useState("");
   // 날짜 검증 함수 추가
   const validateDates = useCallback((start: string, end: string) => {
     if (!start || !end) return;
@@ -240,8 +242,11 @@ export default function WriteForm({ type, initialReferences }: WriteFormProps) {
           throw new Error(`Unknown type: ${type}`);
       }
     } catch (error) {
+      const err = error as AxiosError<{ message?: string }>;
+      setAlertMessage(
+        err.response?.data?.message || "요청 처리 중 오류가 발생했습니다."
+      );
       setAlertOpen(true);
-      throw error;
     }
   };
 
@@ -777,7 +782,7 @@ export default function WriteForm({ type, initialReferences }: WriteFormProps) {
       </div>
       <AlertModal
         isOpen={alertOpen}
-        message="생성 중 오류가 발생했습니다."
+        message={alertMessage}
         type="error"
         duration={3000}
         onClose={() => setAlertOpen(false)}

--- a/src/components/write/CCWriteForm.tsx
+++ b/src/components/write/CCWriteForm.tsx
@@ -88,7 +88,13 @@ export default function WriteForm({ type, initialReferences }: WriteFormProps) {
     }
   }, []);
 
-  // useEffect로 날짜 변경 감지
+  const [startWeek, setStartWeek] = useState("");
+  const [endWeek, setEndWeek] = useState("");
+  useEffect(() => {
+    setStartWeek(getNextMonday());
+    setEndWeek(getNextSunday());
+  }, []);
+
   useEffect(() => {
     validateDates(startDate, endDate);
   }, [startDate, endDate, validateDates]);
@@ -121,8 +127,6 @@ export default function WriteForm({ type, initialReferences }: WriteFormProps) {
   const updateExternalLink = (field: "title" | "url", value: string) => {
     setExternalUrl((prev) => ({ ...prev, [field]: value }));
   };
-  const startWeek = getNextMonday();
-  const endWeek = getNextSunday();
 
   const handleSubmit = async () => {
     try {

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -2,6 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+function parseTimeToMinutes(time: string): number {
+  if (time === "선택") return -1;
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
 export const useModal = () => {
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
@@ -23,37 +29,49 @@ export const useModal = () => {
 
   const modalOutsideRef = useRef<HTMLDivElement | null>(null);
 
-  const toggleDropdown = () => {
-    setIsTypeDropdownOpen((prev) => !prev);
-  };
-
-  const toggleStartTimeDropdown = () => {
+  const toggleDropdown = () => setIsTypeDropdownOpen((prev) => !prev);
+  const toggleStartTimeDropdown = () =>
     setIsStartTimeDropdownOpen((prev) => !prev);
-  };
+  const toggleEndTimeDropdown = () => setIsEndTimeDropdownOpen((prev) => !prev);
 
-  const toggleEndTimeDropdown = () => {
-    setIsEndTimeDropdownOpen((prev) => !prev);
-  };
   const handleType = useCallback((type: string) => {
     setSelectedType(type);
     setIsTypeDropdownOpen(false);
   }, []);
 
   const handleStartTime = (time: string) => {
-    if (selectedEndTime !== "선택" && time >= selectedEndTime) {
-      setTimeError("시작 시간은 종료 시간보다 빨라야 합니다.");
-    } else {
-      setTimeError("");
+    const startMinutes = parseTimeToMinutes(time);
+    const endMinutes = parseTimeToMinutes(selectedEndTime);
+
+    if (endMinutes !== -1) {
+      if (startMinutes === endMinutes) {
+        setTimeError("시작 시간과 종료 시간이 같을 수 없습니다.");
+      } else if (startMinutes > endMinutes) {
+        setTimeError(
+          "시작 시간은 종료 시간보다 빨라야 합니다. (자정을 넘어가는 예약의 경우는 제외)"
+        );
+      } else {
+        setTimeError("");
+      }
     }
     setSelectedStartTime(time);
     setIsStartTimeDropdownOpen(false);
   };
 
   const handleEndTime = (time: string) => {
-    if (selectedStartTime !== "선택" && selectedStartTime >= time) {
-      setTimeError("종료 시간은 시작 시간보다 늦어야 합니다.");
-    } else {
-      setTimeError("");
+    const endMinutes = parseTimeToMinutes(time);
+    const startMinutes = parseTimeToMinutes(selectedStartTime);
+
+    if (startMinutes !== -1) {
+      if (startMinutes === endMinutes) {
+        setTimeError("시작 시간과 종료 시간이 같을 수 없습니다.");
+      } else if (endMinutes < startMinutes) {
+        setTimeError(
+          "시작 시간은 종료 시간보다 빨라야 합니다. (자정을 넘어가는 예약의 경우는 제외)"
+        );
+      } else {
+        setTimeError("");
+      }
     }
     setSelectedEndTime(time);
     setIsEndTimeDropdownOpen(false);

--- a/src/hooks/useSchedule.tsx
+++ b/src/hooks/useSchedule.tsx
@@ -8,9 +8,9 @@ export const useSchedule = () => {
     null
   );
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  // 30분 간격으로 시간 배열 생성 (09:00 ~ 22:00)
-  const timeOptions = [];
-  for (let hour = 9; hour <= 22; hour++) {
+  // 30분 간격으로 시간 배열 생성 (00:00 ~ 23:30) + 23:59 추가
+  const timeOptions: string[] = [];
+  for (let hour = 0; hour < 24; hour++) {
     for (let minute = 0; minute < 60; minute += 30) {
       const timeString = `${hour.toString().padStart(2, "0")}:${minute
         .toString()
@@ -18,6 +18,8 @@ export const useSchedule = () => {
       timeOptions.push(timeString);
     }
   }
+  timeOptions.push("23:59");
+
   return {
     selectedSchedule,
     setSelectedSchedule,

--- a/src/types/attachedFile.ts
+++ b/src/types/attachedFile.ts
@@ -10,7 +10,8 @@ export type AttachedType =
   | "PNG"
   | "JPEG"
   | "JPG"
-  | "ZIP";
+  | "ZIP"
+  | "CSV";
 
 // 첨부파일 타입 정의
 export interface AttachedFile {

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -64,6 +64,7 @@ export interface BlogDataType {
   referenceTitle: string;
   referenceId: number;
   isPublic: boolean;
+  blogCreatorProfileImageUrl: string;
 }
 
 export interface BlogDetailDataType extends BlogDataType {

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -46,7 +46,7 @@ export type SubCategoryType =
   | "데이터베이스"
   | "C/C++"
   | "Python"
-  | "어샘블리어"
+  | "어셈블리어"
   | "JavaScript"
   | "개발 생명주기"
   | "소프트웨어 설계"
@@ -188,7 +188,7 @@ export const SUBCATEGORY_OPTIONS: readonly SubCategoryType[] = [
   "데이터베이스",
   "C/C++",
   "Python",
-  "어샘블리어",
+  "어셈블리어",
   "JavaScript",
   "개발 생명주기",
   "소프트웨어 설계",
@@ -326,7 +326,7 @@ export const SUBCATEGORY_MAP: Record<CategoryType, readonly SubCategoryType[]> =
       "데이터베이스",
       "C/C++",
       "Python",
-      "어샘블리어",
+      "어셈블리어",
       "JavaScript",
       "개발 생명주기",
       "소프트웨어 설계",
@@ -485,7 +485,7 @@ export const SUBCATEGORY_LABELS = {
   데이터베이스: "데이터베이스",
   "C/C++": "C/C++",
   Python: "Python",
-  어샘블리어: "어샘블리어",
+  어셈블리어: "어셈블리어",
   JavaScript: "JavaScript",
   "개발 생명주기": "개발 생명주기",
   "소프트웨어 설계": "소프트웨어 설계",
@@ -635,7 +635,7 @@ export const SUBCATEGORY_TO_EN: Record<SubCategoryType, string> = {
   데이터베이스: "DATABASE",
   "C/C++": "C_CPP",
   Python: "PYTHON",
-  어샘블리어: "ASSEMBLY",
+  어셈블리어: "ASSEMBLY",
   JavaScript: "JAVASCRIPT",
   "개발 생명주기": "SDLC",
   "소프트웨어 설계": "SOFTWARE_DESIGN",

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -145,6 +145,7 @@ export interface ProjectMaterial {
   maxParticipantNumber: number;
   currentParticipantNumber: number;
   participantable: boolean;
+  profileImageUrl: string;
 }
 export interface ProjectSearchParams {
   search?: string;

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -205,3 +205,11 @@ export function normalizeSemester(value: string): string {
   // 뒤에 두 자리 패딩
   return `${year}-${sem.padStart(2, "0")}`;
 }
+
+// study, project 참가자타입
+export interface ParticipantType {
+  memberId: number;
+  memberName: string;
+  memberGrade: MemberGrade;
+  profileImageUrl?: string;
+}

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -98,6 +98,7 @@ export interface StudyMaterial {
   status: StatusType;
   creatorId: number;
   content: string;
+  studyCreatorProfileImageUrl: string;
 }
 
 export interface SortInfo {

--- a/src/utils/attachedFileUtils.ts
+++ b/src/utils/attachedFileUtils.ts
@@ -34,6 +34,7 @@ export function mapToAttachedType(
   if (mime.includes("presentation") || ["ppt", "pptx"].includes(ext))
     return ext === "pptx" ? "PPTX" : "PPT";
   if (mime.includes("excel") || ["xls", "xlsx"].includes(ext)) return "EXCEL";
+  if (mime === "text/csv" || ext === "csv") return "CSV";
   if (mime === "text/plain" || ext === "txt") return "TEXT";
 
   // 이미지

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -23,17 +23,20 @@ export function getDDay(target: string): string {
 
 // 시작주 선택시 월요일만 선택
 export const getNextMonday = () => {
-  const today = new Date();
-  const day = today.getDay();
+  const now = new Date();
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000); // UTC+9 보정
+  const day = kst.getUTCDay();
   const diff = (8 - day) % 7;
-  today.setDate(today.getDate() + diff);
-  return today.toISOString().split("T")[0];
+  kst.setDate(kst.getDate() + diff);
+  return kst.toISOString().split("T")[0];
 };
+
 // 종료주 선택시 일요일만 선택
 export const getNextSunday = () => {
-  const today = new Date();
-  const day = today.getDay();
+  const now = new Date();
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const day = kst.getUTCDay();
   const diff = (7 - day) % 7;
-  today.setDate(today.getDate() + diff);
-  return today.toISOString().split("T")[0];
+  kst.setDate(kst.getDate() + diff);
+  return kst.toISOString().split("T")[0];
 };

--- a/src/utils/formatDateUtil.ts
+++ b/src/utils/formatDateUtil.ts
@@ -60,16 +60,9 @@ export const formatDate = (
     }
 
     // short
-    const year = date.toLocaleDateString("ko-KR", {
-      ...options,
-      year: "numeric",
-    });
-    const month = date
-      .toLocaleDateString("ko-KR", { ...options, month: "2-digit" })
-      .replace(/[^0-9]/g, "");
-    const day = date
-      .toLocaleDateString("ko-KR", { ...options, day: "2-digit" })
-      .replace(/[^0-9]/g, "");
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
   } catch (error) {
     console.warn("Date formatting error:", error);

--- a/src/utils/formatDateUtil.ts
+++ b/src/utils/formatDateUtil.ts
@@ -29,9 +29,11 @@ export const formatDate = (
         : dateInput;
 
     if (isNaN(date.getTime())) return String(dateInput);
+    const options: Intl.DateTimeFormatOptions = { timeZone: "Asia/Seoul" };
 
     if (format === "long") {
       return date.toLocaleDateString("ko-KR", {
+        ...options,
         year: "numeric",
         month: "long",
         day: "numeric",
@@ -41,6 +43,7 @@ export const formatDate = (
 
     if (format === "medium") {
       return date.toLocaleDateString("ko-KR", {
+        ...options,
         month: "long",
         day: "numeric",
         weekday: "long",
@@ -49,6 +52,7 @@ export const formatDate = (
 
     if (format === "dot") {
       return date.toLocaleDateString("ko-KR", {
+        ...options,
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
@@ -56,9 +60,16 @@ export const formatDate = (
     }
 
     // short
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
+    const year = date.toLocaleDateString("ko-KR", {
+      ...options,
+      year: "numeric",
+    });
+    const month = date
+      .toLocaleDateString("ko-KR", { ...options, month: "2-digit" })
+      .replace(/[^0-9]/g, "");
+    const day = date
+      .toLocaleDateString("ko-KR", { ...options, day: "2-digit" })
+      .replace(/[^0-9]/g, "");
     return `${year}-${month}-${day}`;
   } catch (error) {
     console.warn("Date formatting error:", error);
@@ -88,6 +99,7 @@ export const formatTime = (
       hour: "2-digit",
       minute: "2-digit",
       hour12: false,
+      timeZone: "Asia/Seoul",
     };
 
     if (format === "hms") {

--- a/src/utils/formatDateUtil.ts
+++ b/src/utils/formatDateUtil.ts
@@ -100,3 +100,31 @@ export const formatTime = (
     return String(dateInput);
   }
 };
+
+/**
+ * 시작일과 종료일을 범위 형식으로 포맷팅합니다.
+ * 같은 날이면 시작일만, 다르면 "YYYY.MM.DD ~ YYYY.MM.DD" 형식 반환
+ */
+export const formatDateRange = (
+  startInput: Date | string,
+  endInput: Date | string,
+  format: "dot" | "short" | "medium" | "long" = "dot"
+): string => {
+  const startDate =
+    typeof startInput === "string" ? new Date(startInput) : startInput;
+  const endDate = typeof endInput === "string" ? new Date(endInput) : endInput;
+
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    return `${startInput} ~ ${endInput}`;
+  }
+
+  const startStr = formatDate(startDate, format);
+  const endStr = formatDate(endDate, format);
+
+  const sameDay =
+    startDate.getFullYear() === endDate.getFullYear() &&
+    startDate.getMonth() === endDate.getMonth() &&
+    startDate.getDate() === endDate.getDate();
+
+  return sameDay ? startStr : `${startStr} ~ ${endStr}`;
+};

--- a/src/utils/newPageFormUtils.ts
+++ b/src/utils/newPageFormUtils.ts
@@ -46,7 +46,7 @@ export const getSubCategories = (mainCategory: string): string[] => {
       "데이터베이스",
       "C/C++",
       "Python",
-      "어샘블리어",
+      "어셈블리어",
       "JavaScript",
       "개발 생명주기",
       "소프트웨어 설계",

--- a/src/utils/studyHelper.tsx
+++ b/src/utils/studyHelper.tsx
@@ -42,7 +42,7 @@ export function isSubCategoryType(value: string): value is SubCategoryType {
     "데이터베이스",
     "C/C++",
     "Python",
-    "어샘블리어",
+    "어셈블리어",
     "JavaScript",
     "개발 생명주기",
     "소프트웨어 설계",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #99

## 📝작업 내용

- writeForm, editForm 시작주 종료주 
      - utc로 인해서 자정이 넘어가도 실제 요일이 반영되지 않아서 kst로 변환하는 코드 추가
      - 관리자만 시작주, 종료주 변경할 수 있도록 api 추가
- cs-어셈블리어 오타 수정
- csv 형식 추가
- board, study, project, blog 프로필 이미지 추가
- study, project 참가 승인/거절, 개설 승인/거절 구조 변경에 따른 코드 수정
- /profile의 SCTodaySchedule에서 `key = {schedule.scheduleId}` → `key = {schedule.id}`로  key 값 수정
- schedule
    - 스켈레톤 추가
    - formatDate util : utc -> kst로 변환되게 수정
    - 예약 시간 수정
    
    ```sql
    ## 시간 조건 + 예시
    1. 같은 날 예약
    ex1) 시작 09:00 → 종료 12:00
    → 총 3시간 예약 ✅ (허용)
    
    ex2) 시작 14:00 → 종료 14:00
    → 예약 시간이 0시간 ❌ → "시작시간과 종료시간은 같을 수 없습니다." (에러)
    
    2. 자정을 넘기는 예약
    
    ex1) 시작 22:00 → 종료 02:00 (다음날)
    → 종료 시간을 하루 뒤로 보정 → 총 4시간 예약 ✅ (허용)
    
    ex2) 시작 18:00 → 종료 17:00 (다음날)
    → 총 23시간 예약 ✅ (허용, 최대치)
    
    ex3) 시작 18:00 → 종료 18:30 (다음날)
    → 총 24시간 30분 ❌ → "자정을 넘기는 예약은 최대 23시간까지만 허용됩니다." (에러)
    
    ## 총정리
    - 같은 날 예약은 단순히 시작~종료 시간 차이만 계산합니다.
    - 자정을 넘기는 예약은 자동으로 다음날 종료로 보정하며, 최대 23시간까지만 허용됩니다.
    - 시작/종료 시간이 같거나 23시간을 초과하면 예약이 차단되고, 경고 메시지가 표시됩니다.
    ```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/5d05a6ff-d7a7-4afc-b2e2-06fcebef192b


예시) 사용자가 board 게시글 작성 시도할 때
<img width="414" height="90" alt="image" src="https://github.com/user-attachments/assets/2d6300d1-1196-4b9a-856f-dbf722d669f8" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
