### PR TITLE
Feat, Fix: 멤버 CSV 추출 + Study/project 스터디원 리스트 페이지네이션 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "file-saver": "^2.0.5",
         "framer-motion": "^12.23.22",
         "highlight.js": "^11.11.1",
         "jose": "^6.0.13",
@@ -31,12 +32,14 @@
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
+        "xlsx": "^0.18.5",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@svgr/webpack": "^8.1.0",
         "@tailwindcss/postcss": "^4",
+        "@types/file-saver": "^2.0.7",
         "@types/gtag.js": "^0.0.20",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -5081,6 +5084,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/gtag.js": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
@@ -6005,6 +6015,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -6602,6 +6621,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6748,6 +6780,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -6881,6 +6922,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -8263,6 +8316,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8369,6 +8428,15 @@
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/framer-motion": {
       "version": "12.23.22",
@@ -12666,6 +12734,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -13849,6 +13929,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -13878,6 +13976,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "file-saver": "^2.0.5",
     "framer-motion": "^12.23.22",
     "highlight.js": "^11.11.1",
     "jose": "^6.0.13",
@@ -32,12 +33,14 @@
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
+    "xlsx": "^0.18.5",
     "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@svgr/webpack": "^8.1.0",
     "@tailwindcss/postcss": "^4",
+    "@types/file-saver": "^2.0.7",
     "@types/gtag.js": "^0.0.20",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/(admin)/admin/blog/[id]/loading.tsx
+++ b/src/app/(admin)/admin/blog/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-transparent">
+      <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-red-500"></div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/study/[id]/loading.tsx
+++ b/src/app/(admin)/admin/study/[id]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-transparent">
+      <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-red-500"></div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/projectDetailPage.tsx
@@ -12,19 +12,14 @@ import SCProjectMeetingMinutes from "@/components/project/SCProjectMeetingMinute
 import EndRequestButton from "@/components/ui/endRequestButton";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getStatusColor } from "@/utils/badgeUtils";
-import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
-import { MEMBER_GRADE_LABELS, ParticipantType } from "@/types/study";
+import { MEMBER_GRADE_LABELS } from "@/types/study";
 import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { formatDate } from "@/utils/formatDateUtil";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
 import { getDetailProject } from "@/app/api/project/SCProjectApi";
-import {
-  getProjectApprovedParticipants,
-  getProjectPendingParticipants,
-} from "@/app/api/project/SCProjectParticipantApi";
 import { getCurrentUser } from "@/lib/auth/currentUser";
-import LogoSVG from "/public/icons/logo.svg";
 import { getStudyPeriodLabel } from "@/utils/studyHelper";
+import CCParticipantsList from "@/components/detail/CCParticipantsList";
 
 interface ProjectDetailPageProps {
   params: { id: string };
@@ -43,14 +38,6 @@ export default async function ProjectDetailPage({
 
   // 현재 유저 판별
   const currentUser = await getCurrentUser();
-
-  // 승인된 프로젝트원
-  const approvedData = await getProjectApprovedParticipants(projectId, 0, 10);
-  const approvedMember = approvedData.content ?? [];
-
-  // 대기 중인 프로젝트원
-  const pendingData = await getProjectPendingParticipants(projectId, 0, 10);
-  const pendingMember = pendingData.content ?? [];
 
   return (
     <div className="mx-auto max-w-full">
@@ -283,89 +270,11 @@ export default async function ProjectDetailPage({
           {/* 멤버 목록: 오른쪽 1/3 */}
           <div className="basis-1/3 h-full overflow-y-auto dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
             <div className="p-6">
-              <h3 className="text-lg font-bold text-black dark:text-white mb-4">
-                프로젝트원 ({approvedMember.length})
-              </h3>
-
-              <div className="mb-6 space-y-3">
-                {approvedMember.length > 0 ? (
-                  approvedMember.map((participant: ParticipantType) => (
-                    <div
-                      key={participant.memberId}
-                      className="flex items-center gap-3"
-                    >
-                      <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                        {participant.profileImageUrl ? (
-                          <Image
-                            src={participant.profileImageUrl}
-                            alt={`${participant.memberName} 프로필`}
-                            fill
-                            className="object-cover"
-                          />
-                        ) : (
-                          <LogoSVG className="w-8 h-8 text-gray-400" />
-                        )}
-                      </div>
-                      <p className="text-sm font-medium text-black dark:text-white">
-                        {participant.memberName}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                      </p>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    참여 중인 멤버가 없습니다.
-                  </p>
-                )}
-              </div>
-
-              <div>
-                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                  대기중 멤버 ({pendingMember.length})
-                </h4>
-                <div className="space-y-3">
-                  {pendingMember.length > 0 ? (
-                    pendingMember.map((participant: ParticipantType) => (
-                      <div
-                        key={participant.memberId}
-                        className="flex items-center gap-3"
-                      >
-                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                          {participant.profileImageUrl ? (
-                            <Image
-                              src={participant.profileImageUrl}
-                              alt={`${participant.memberName} 프로필`}
-                              fill
-                              className="object-cover"
-                            />
-                          ) : (
-                            <LogoSVG className="w-8 h-8 text-gray-400" />
-                          )}
-                        </div>
-                        <p className="text-sm font-medium text-black dark:text-white">
-                          {participant.memberName}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                        </p>
-
-                        <div className="flex gap-2">
-                          <CCParticipantActionButtons
-                            memberId={participant.memberId}
-                            dataId={project.id}
-                          />
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      대기중인 멤버가 없습니다.
-                    </p>
-                  )}
-                </div>
-              </div>
+              <CCParticipantsList
+                type="project"
+                dataId={project.id}
+                size={10}
+              />
             </div>
           </div>
         </div>

--- a/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
+++ b/src/app/(admin)/admin/study/[id]/studyDetailPage.tsx
@@ -15,22 +15,14 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { getStatusColor } from "@/utils/badgeUtils";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { formatDate } from "@/utils/formatDateUtil";
-import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
-import {
-  MEMBER_GRADE_LABELS,
-  ParticipantType,
-  StudyMaterial,
-} from "@/types/study";
+import { MEMBER_GRADE_LABELS, StudyMaterial } from "@/types/study";
 import CCShareButton from "@/components/detail/CCShareButton";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
 import { AttachedFile } from "@/types/attachedFile";
-import {
-  getApprovedParticipants,
-  getPendingParticipants,
-} from "@/app/api/study/SCStudyParticipantApi";
 import { getCurrentUser } from "@/lib/auth/currentUser";
 import { getDetailStudy } from "@/app/api/study/SCStudyApi";
 import LogoSVG from "/public/icons/logo.svg";
+import CCParticipantsList from "@/components/detail/CCParticipantsList";
 
 interface StudyDetailPageProps {
   params: { id: string };
@@ -49,14 +41,6 @@ export default async function StudyDetailPage({
 
   // 현재 유저 판별
   const currentUser = await getCurrentUser();
-
-  // 승인된 스터디원
-  const approvedData = await getApprovedParticipants(studyId, 0, 10);
-  const approvedMember = approvedData.content ?? [];
-
-  // 대기 중인 스터디원
-  const pendingData = await getPendingParticipants(studyId, 0, 10);
-  const pendingMember = pendingData.content ?? [];
 
   return (
     <div>
@@ -231,91 +215,11 @@ export default async function StudyDetailPage({
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
             <div className="p-6">
-              <h3 className="text-lg font-bold text-black dark:text-white mb-4">
-                스터디원 ({approvedMember.length})
-              </h3>
-
-              <div className="mb-6">
-                <div className="space-y-3">
-                  {approvedMember.length > 0 ? (
-                    approvedMember.map((participant: ParticipantType) => (
-                      <div
-                        key={participant.memberId}
-                        className="flex items-center gap-3"
-                      >
-                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                          {participant.profileImageUrl ? (
-                            <Image
-                              src={participant.profileImageUrl}
-                              alt={`${participant.memberName} 프로필`}
-                              fill
-                              className="object-cover"
-                            />
-                          ) : (
-                            <LogoSVG className="w-8 h-8 text-gray-400" />
-                          )}
-                        </div>
-                        <p className="text-sm font-medium text-black dark:text-white">
-                          {participant.memberName}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                        </p>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      참여 중인 멤버가 없습니다.
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                  대기중 멤버 ({pendingMember.length})
-                </h4>
-                <div className="space-y-3">
-                  {pendingMember.length > 0 ? (
-                    pendingMember.map((participant: ParticipantType) => (
-                      <div
-                        key={participant.memberId}
-                        className="flex items-center gap-3"
-                      >
-                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                          {participant.profileImageUrl ? (
-                            <Image
-                              src={participant.profileImageUrl}
-                              alt={`${participant.memberName} 프로필`}
-                              fill
-                              className="object-cover"
-                            />
-                          ) : (
-                            <LogoSVG className="w-8 h-8 text-gray-400" />
-                          )}
-                        </div>
-                        <p className="text-sm font-medium text-black dark:text-white">
-                          {participant.memberName}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                        </p>
-
-                        <div className="flex gap-2">
-                          <CCParticipantActionButtons
-                            memberId={participant.memberId}
-                            dataId={studyData.id}
-                          />
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      대기중인 멤버가 없습니다.
-                    </p>
-                  )}
-                </div>
-              </div>
+              <CCParticipantsList
+                type="study"
+                dataId={studyData.id}
+                size={10}
+              />
             </div>
           </div>
 

--- a/src/app/(main)/project/[id]/page.tsx
+++ b/src/app/(main)/project/[id]/page.tsx
@@ -13,20 +13,19 @@ import EndRequestButton from "@/components/ui/endRequestButton";
 import { getStatusColor } from "@/utils/badgeUtils";
 import { STATUS_LABELS } from "@/types/progressStatus";
 import { getDetailProject } from "@/app/api/project/SCProjectApi";
-import { MEMBER_GRADE_LABELS, ParticipantType } from "@/types/study";
+import { MEMBER_GRADE_LABELS } from "@/types/study";
 import { formatDate } from "@/utils/formatDateUtil";
 import { getCurrentUser } from "@/lib/auth/currentUser";
 import {
   getProjectApprovedParticipants,
   getProjectPendingParticipants,
 } from "@/app/api/project/SCProjectParticipantApi";
-import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
 import { CCJoinButton } from "@/components/ui/CCJoinButton";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
 import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { ProjectMaterial } from "@/types/project";
 import { getStudyPeriodLabel } from "@/utils/studyHelper";
-import LogoSVG from "/public/icons/logo.svg";
+import CCParticipantsList from "@/components/detail/CCParticipantsList";
 
 interface ProjectDetailPageProps {
   params: Promise<{ id: string }>;
@@ -346,92 +345,12 @@ export default async function ProjectDetailPage({
           {/* 멤버 목록: 오른쪽 1/3 */}
           <div className="basis-1/3 h-full overflow-y-auto dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
             <div className="p-6">
-              <h3 className="text-lg font-bold text-black dark:text-white mb-4">
-                프로젝트원 ({approvedMember.length})
-              </h3>
-
-              <div className="mb-6 space-y-3">
-                {approvedMember.length > 0 ? (
-                  approvedMember.map((participant: ParticipantType) => (
-                    <div
-                      key={participant.memberId}
-                      className="flex items-center gap-3"
-                    >
-                      <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                        {participant.profileImageUrl ? (
-                          <Image
-                            src={participant.profileImageUrl}
-                            alt={`${participant.memberName} 프로필`}
-                            fill
-                            className="object-cover"
-                          />
-                        ) : (
-                          <LogoSVG className="w-8 h-8 text-gray-400" />
-                        )}
-                      </div>
-                      <p className="text-sm font-medium text-black dark:text-white">
-                        {participant.memberName}
-                      </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                      </p>
-                    </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    참여 중인 멤버가 없습니다.
-                  </p>
-                )}
-              </div>
-
-              {canApproveOrReject && (
-                <div>
-                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                    대기중 멤버 ({pendingMember.length})
-                  </h4>
-                  <div className="space-y-3">
-                    {pendingMember.length > 0 ? (
-                      pendingMember.map((participant: ParticipantType) => (
-                        <div
-                          key={participant.memberId}
-                          className="flex items-center gap-3"
-                        >
-                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                            {participant.profileImageUrl ? (
-                              <Image
-                                src={participant.profileImageUrl}
-                                alt={`${participant.memberName} 프로필`}
-                                fill
-                                className="object-cover"
-                              />
-                            ) : (
-                              <LogoSVG className="w-8 h-8 text-gray-400" />
-                            )}
-                          </div>
-                          <p className="text-sm font-medium text-black dark:text-white">
-                            {participant.memberName}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                          </p>
-                          {canApproveOrReject && (
-                            <div className="flex gap-2">
-                              <CCParticipantActionButtons
-                                memberId={participant.memberId}
-                                dataId={project.id}
-                              />
-                            </div>
-                          )}
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        대기중인 멤버가 없습니다.
-                      </p>
-                    )}
-                  </div>
-                </div>
-              )}
+              <CCParticipantsList
+                type="project"
+                dataId={project.id}
+                size={10}
+                canApproveOrReject={!!canApproveOrReject}
+              />
             </div>
           </div>
         </div>

--- a/src/app/(main)/study/[id]/page.tsx
+++ b/src/app/(main)/study/[id]/page.tsx
@@ -19,19 +19,15 @@ import { getDetailStudy } from "@/app/api/study/SCStudyApi";
 import { formatDate } from "@/utils/formatDateUtil";
 import { SUBCATEGORY_FROM_EN } from "@/types/category";
 import {
-  getApprovedParticipants,
-  getPendingParticipants,
+  getStudyApprovedParticipants,
+  getStudyPendingParticipants,
 } from "@/app/api/study/SCStudyParticipantApi";
 import { CCJoinButton } from "@/components/ui/CCJoinButton";
 import { getCurrentUser } from "@/lib/auth/currentUser";
-import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
 import MeetingMinutes from "@/components/study/SCStudyMeetingMinutes";
+import CCParticipantsList from "@/components/detail/CCParticipantsList";
 import { AttachedFile } from "@/types/attachedFile";
-import {
-  MEMBER_GRADE_LABELS,
-  ParticipantType,
-  StudyMaterial,
-} from "@/types/study";
+import { MEMBER_GRADE_LABELS, StudyMaterial } from "@/types/study";
 import LogoSVG from "/public/icons/logo.svg";
 
 // 메타데이터 생성
@@ -89,11 +85,11 @@ export default async function StudyMaterialDetailPage({
     currentUser && currentUser.sub === String(studyData.creatorId);
 
   // 승인된 스터디원
-  const approvedData = await getApprovedParticipants(studyId, 0, 10);
+  const approvedData = await getStudyApprovedParticipants(studyId, 0, 10);
   const approvedMember = approvedData.content ?? [];
 
   // 대기 중인 스터디원
-  const pendingData = await getPendingParticipants(studyId, 0, 10);
+  const pendingData = await getStudyPendingParticipants(studyId, 0, 10);
   const pendingMember = pendingData.content ?? [];
   const isAlreadyApproved = approvedMember.some(
     (m: { memberId: number }) => String(m.memberId) === String(currentUser?.sub)
@@ -307,95 +303,12 @@ export default async function StudyMaterialDetailPage({
 
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
             <div className="p-6">
-              <h3 className="text-lg font-bold text-black dark:text-white mb-4">
-                스터디원 ({approvedMember.length})
-              </h3>
-
-              <div className="mb-6">
-                <div className="space-y-3">
-                  {approvedMember.length > 0 ? (
-                    approvedMember.map((participant: ParticipantType) => (
-                      <div
-                        key={participant.memberId}
-                        className="flex items-center gap-3"
-                      >
-                        <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                          {participant.profileImageUrl ? (
-                            <Image
-                              src={participant.profileImageUrl}
-                              alt={`${participant.memberName} 프로필`}
-                              fill
-                              className="object-cover"
-                            />
-                          ) : (
-                            <LogoSVG className="w-8 h-8 text-gray-400" />
-                          )}
-                        </div>
-                        <p className="text-sm font-medium text-black dark:text-white">
-                          {participant.memberName}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                        </p>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      참여 중인 멤버가 없습니다.
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {canApproveOrReject && (
-                <div>
-                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                    대기중 멤버 ({pendingMember.length})
-                  </h4>
-                  <div className="space-y-3">
-                    {pendingMember.length > 0 ? (
-                      pendingMember.map((participant: ParticipantType) => (
-                        <div
-                          key={participant.memberId}
-                          className="flex items-center gap-3"
-                        >
-                          <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200 flex items-center justify-center text-xs font-medium text-black dark:bg-gray-700 dark:text-white">
-                            {participant.profileImageUrl ? (
-                              <Image
-                                src={participant.profileImageUrl}
-                                alt={`${participant.memberName} 프로필`}
-                                fill
-                                className="object-cover"
-                              />
-                            ) : (
-                              <LogoSVG className="w-8 h-8 text-gray-400" />
-                            )}
-                          </div>
-                          <p className="text-sm font-medium text-black dark:text-white">
-                            {participant.memberName}
-                          </p>
-                          <p className="text-xs text-gray-500 dark:text-gray-400">
-                            {MEMBER_GRADE_LABELS[participant.memberGrade]}
-                          </p>
-
-                          {canApproveOrReject && (
-                            <div className="flex gap-2">
-                              <CCParticipantActionButtons
-                                memberId={participant.memberId}
-                                dataId={studyData.id}
-                              />
-                            </div>
-                          )}
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        대기중인 멤버가 없습니다.
-                      </p>
-                    )}
-                  </div>
-                </div>
-              )}
+              <CCParticipantsList
+                type="study"
+                dataId={studyData.id}
+                size={10}
+                canApproveOrReject={!!canApproveOrReject}
+              />
             </div>
           </div>
 

--- a/src/app/api/project/CCProjectParticipantApi.tsx
+++ b/src/app/api/project/CCProjectParticipantApi.tsx
@@ -68,3 +68,29 @@ export async function rejectProjectParticipant(
     throw error;
   }
 }
+
+// 승인된 참가자 조회
+export async function getProjectApprovedParticipants(
+  projectId: number,
+  page = 0,
+  size = 10
+) {
+  const res = await apiClient.get(
+    `/project/participant/${projectId}/participants/approved`,
+    { params: { page, size, sort: "createdAt,desc" } }
+  );
+  return res.data.data;
+}
+
+// 대기중 참가자 조회
+export async function getProjectPendingParticipants(
+  projectId: number,
+  page = 0,
+  size = 10
+) {
+  const res = await apiClient.get(
+    `/project/participant/${projectId}/participants/pending`,
+    { params: { page, size, sort: "createdAt,desc" } }
+  );
+  return res.data.data;
+}

--- a/src/app/api/study/CCStudyParticipantApi.tsx
+++ b/src/app/api/study/CCStudyParticipantApi.tsx
@@ -68,3 +68,29 @@ export async function rejectStudyParticipant(
     throw error;
   }
 }
+
+// 승인된 참가자 조회
+export async function getStudyApprovedParticipants(
+  studyId: number,
+  page = 0,
+  size = 10
+) {
+  const res = await apiClient.get(
+    `/study/participant/${studyId}/participants/approved`,
+    { params: { page, size, sort: "createdAt,desc" } }
+  );
+  return res.data.data;
+}
+
+// 대기중 참가자 조회
+export async function getStudyPendingParticipants(
+  studyId: number,
+  page = 0,
+  size = 10
+) {
+  const res = await apiClient.get(
+    `/study/participant/${studyId}/participants/pending`,
+    { params: { page, size, sort: "createdAt,desc" } }
+  );
+  return res.data.data;
+}

--- a/src/app/api/study/SCStudyParticipantApi.tsx
+++ b/src/app/api/study/SCStudyParticipantApi.tsx
@@ -1,37 +1,7 @@
 import { fetchWithAuth } from "@/lib/serverIntercept";
 
-export async function getStudyAllParticipants(
-  studyId: number,
-  page: number = 0,
-  size: number = 10,
-  sort: string[] = ["createdAt,desc"]
-) {
-  try {
-    const params = new URLSearchParams();
-    params.append("page", page.toString());
-    params.append("size", size.toString());
-    sort.forEach((s) => params.append("sort", s));
-
-    const res = await fetchWithAuth(
-      `/study/participant/${studyId}/participants/all?${params.toString()}`,
-      {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-      }
-    );
-
-    if (!res.ok) {
-      throw new Error(`스터디 참가자 전체 조회 실패: ${res.status}`);
-    }
-    const json = await res.json();
-    return json.data;
-  } catch (error) {
-    throw error;
-  }
-}
-
 // 승인된 참가자 조회
-export async function getApprovedParticipants(
+export async function getStudyApprovedParticipants(
   studyId: number,
   page: number = 0,
   size: number = 10,
@@ -56,7 +26,6 @@ export async function getApprovedParticipants(
     }
 
     const json = await res.json();
-    console.log(json);
     return json.data;
   } catch (error) {
     throw error;
@@ -64,7 +33,7 @@ export async function getApprovedParticipants(
 }
 
 // 대기중 참가자 조회
-export async function getPendingParticipants(
+export async function getStudyPendingParticipants(
   studyId: number,
   page: number = 0,
   size: number = 10,
@@ -89,7 +58,6 @@ export async function getPendingParticipants(
     }
 
     const json = await res.json();
-    console.log("대기중", json);
     return json.data;
   } catch (error) {
     throw error;

--- a/src/components/admin/members/CCMembersList.tsx
+++ b/src/components/admin/members/CCMembersList.tsx
@@ -8,25 +8,100 @@ import CCMemberDetailCard from "@/components/admin/members/CCMemberDetailCard";
 import { translateMemberRole } from "@/utils/transfromResponseValue";
 
 interface CCMembersListProps {
-  filteredMembers: AdminMemberDetailInfoType[]; // 서버에서 필터된 결과
+  filteredMembers: AdminMemberDetailInfoType[];
 }
 
 export default function CCMembersList({ filteredMembers }: CCMembersListProps) {
   const [selectedMember, setSelectedMember] =
     useState<AdminMemberDetailInfoType | null>(null);
 
+  /** CSV로 변환 후 다운로드하는 함수 */
+  const handleExportCSV = () => {
+    if (filteredMembers.length === 0) {
+      alert("내보낼 회원 데이터가 없습니다.");
+      return;
+    }
+
+    // CSV 헤더
+    const headers = [
+      "이름",
+      "전공",
+      "학번",
+      "학년",
+      "생일",
+      "전화번호",
+      "이메일",
+      "성별",
+      "가입일",
+      "역할",
+      "활동 스터디",
+      "활동 프로젝트",
+      "벌점",
+      "유예 기간",
+    ];
+
+    // 데이터 변환 (헤더와 매칭)
+    const rows = filteredMembers.map((m) => [
+      m.name ?? "",
+      m.major ?? "",
+      m.studentNumber ?? "",
+      m.grade ?? "",
+      m.birthday ?? "",
+      m.phoneNumber ?? "",
+      m.email ?? "",
+      m.gender ?? "",
+      m.createdAt ? new Date(m.createdAt).toLocaleDateString() : "",
+      translateMemberRole(m.role) ?? "",
+      (m.activeStudies || []).join(", "),
+      (m.activeProjects || []).join(", "),
+      m.penaltyPoints ?? 0,
+      m.gracePeriod ? new Date(m.gracePeriod).toLocaleDateString() : "",
+    ]);
+
+    // CSV 문자열 생성
+    const csvContent = [
+      headers.join(","), // 첫 줄: 헤더
+      ...rows.map((r) =>
+        r
+          .map((v) => (typeof v === "string" && v.includes(",") ? `"${v}"` : v))
+          .join(",")
+      ),
+    ].join("\n");
+
+    // Blob 생성 & 다운로드
+    const blob = new Blob(["\uFEFF" + csvContent], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `members_${new Date().toISOString().slice(0, 10)}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="flex gap-8 w-full">
       {/* 멤버 목록 */}
       <div className="flex-1 rounded-lg border border-gray-200 shadow-sm">
-        <div className="px-6 py-4 border-b border-gray-300 flex items-center">
+        <div className="px-6 py-4 border-b border-gray-300 flex items-center justify-between">
           <h2 className="text-base font-semibold text-gray-800 flex items-center">
             전체 회원
             <span className="text-sm text-gray-500 flex items-center ml-0.5">
               ({filteredMembers.length}명)
             </span>
           </h2>
+
+          {/* 🔹 CSV 내보내기 버튼 */}
+          <button
+            onClick={handleExportCSV}
+            className="text-sm action-button px-3 py-1.5"
+          >
+            CSV로 내보내기
+          </button>
         </div>
+
         <div className="p-0 overflow-y-auto max-h-[40rem]">
           <table className="w-full text-sm text-gray-600">
             <thead className="bg-gray-50 text-left">

--- a/src/components/admin/members/SCMembersContentWrapper.tsx
+++ b/src/components/admin/members/SCMembersContentWrapper.tsx
@@ -1,7 +1,6 @@
 "server-only";
 
 import SCSearchResultNotFound from "@/components/ui/SCSearchResultNotFound";
-// import { AdminMemberDetailInfoType } from "@/types/admin/adminMembers";
 import CCMembersList from "@/components/admin/members/CCMembersList";
 import { getMembersForStaff } from "@/app/api/member/SCadminMemberApi";
 
@@ -29,6 +28,5 @@ export default async function SCMembersContentWrapper({
     );
   }
 
-  // ✅ 데이터만 클라이언트로 내려서 상호작용은 거기서
   return <CCMembersList filteredMembers={filtered} />;
 }

--- a/src/components/detail/CCParticipantsList.tsx
+++ b/src/components/detail/CCParticipantsList.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import Image from "next/image";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import LogoSVG from "/public/icons/logo.svg";
+import {
+  getStudyApprovedParticipants,
+  getStudyPendingParticipants,
+} from "@/app/api/study/CCStudyParticipantApi";
+import {
+  getProjectApprovedParticipants,
+  getProjectPendingParticipants,
+} from "@/app/api/project/CCProjectParticipantApi";
+import { ParticipantType, MEMBER_GRADE_LABELS } from "@/types/study";
+import CCParticipantActionButtons from "@/components/ui/CCParticipantActionButtons";
+
+interface CCParticipantsListProps {
+  type: "study" | "project";
+  dataId: number;
+  size?: number;
+  canApproveOrReject?: boolean;
+}
+
+export default function CCParticipantsList({
+  type,
+  dataId,
+  size = 10,
+  canApproveOrReject = false,
+}: CCParticipantsListProps) {
+  const pathname = usePathname();
+  const isAdmin = pathname.startsWith("/admin");
+
+  const [approvedPage, setApprovedPage] = useState(0);
+  const [approvedMembers, setApprovedMembers] = useState<ParticipantType[]>([]);
+  const [approvedTotalElements, setApprovedTotalElements] = useState(0);
+  const [approvedTotalPages, setApprovedTotalPages] = useState(1);
+
+  const [pendingPage, setPendingPage] = useState(0);
+  const [pendingMembers, setPendingMembers] = useState<ParticipantType[]>([]);
+  const [pendingTotalElements, setPendingTotalElements] = useState(0);
+  const [pendingTotalPages, setPendingTotalPages] = useState(1);
+
+  const getApprovedAPI =
+    type === "study"
+      ? getStudyApprovedParticipants
+      : getProjectApprovedParticipants;
+  const getPendingAPI =
+    type === "study"
+      ? getStudyPendingParticipants
+      : getProjectPendingParticipants;
+
+  // 승인된 멤버 조회
+  const fetchApproved = async () => {
+    const data = await getApprovedAPI(dataId, approvedPage, size);
+    setApprovedMembers(data.content ?? []);
+    setApprovedTotalElements(data.totalElements ?? 0);
+    setApprovedTotalPages(data.totalPages ?? 1);
+  };
+
+  // 대기중 멤버 조회
+  const fetchPending = async () => {
+    const data = await getPendingAPI(dataId, pendingPage, size);
+    setPendingMembers(data.content ?? []);
+    setPendingTotalElements(data.totalElements ?? 0);
+    setPendingTotalPages(data.totalPages ?? 1);
+  };
+
+  // 최초 및 페이지 이동 시
+  useEffect(() => {
+    fetchApproved();
+  }, [dataId, approvedPage]);
+
+  useEffect(() => {
+    if (isAdmin || canApproveOrReject) {
+      fetchPending();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataId, pendingPage]);
+
+  // 승인 처리
+  const handleApprove = (member: ParticipantType) => {
+    setPendingMembers((prev) =>
+      prev.filter((m) => m.memberId !== member.memberId)
+    );
+    setPendingTotalElements((prev) => Math.max(prev - 1, 0));
+    // 마지막 페이지의 마지막 멤버일 경우 첫 페이지로 이동
+    if (pendingMembers.length === 1 && pendingPage > 0) {
+      setPendingPage(0);
+    }
+    setApprovedMembers((prev) => [member, ...prev].slice(0, size));
+    setApprovedTotalElements((prev) => prev + 1);
+
+    setApprovedTotalPages(Math.ceil((approvedTotalElements + 1) / size));
+  };
+
+  // 거절 처리
+  const handleReject = (memberId: number) => {
+    setPendingMembers((prev) => prev.filter((m) => m.memberId !== memberId));
+    setPendingTotalElements((prev) => Math.max(prev - 1, 0));
+
+    if (pendingMembers.length === 1 && pendingPage > 0) {
+      setPendingPage(0);
+    }
+    // 페이지 수 재계산
+    setPendingTotalPages(
+      Math.max(1, Math.ceil((pendingTotalElements - 1) / size))
+    );
+  };
+
+  const handleApprovedPageChange = (nextPage: number) => {
+    if (nextPage >= 0 && nextPage < approvedTotalPages)
+      setApprovedPage(nextPage);
+  };
+
+  const handlePendingPageChange = (nextPage: number) => {
+    if (nextPage >= 0 && nextPage < pendingTotalPages) setPendingPage(nextPage);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h3 className="text-lg font-bold text-black dark:text-white mb-4">
+        {type === "study" ? "스터디원" : "프로젝트원"} ({approvedTotalElements})
+      </h3>
+
+      {approvedMembers.length > 0 ? (
+        <div className="space-y-3 mb-3">
+          {approvedMembers.map((p) => (
+            <div key={p.memberId} className="flex items-center gap-3">
+              <Avatar profileImageUrl={p.profileImageUrl} />
+              <div>
+                <p className="text-sm font-medium text-black dark:text-white">
+                  {p.memberName}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {MEMBER_GRADE_LABELS[p.memberGrade]}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500 text-center">
+          참여 중인 멤버가 없습니다.
+        </p>
+      )}
+
+      {approvedTotalPages > 1 && (
+        <Pagination
+          page={approvedPage}
+          totalPages={approvedTotalPages}
+          onChange={handleApprovedPageChange}
+        />
+      )}
+
+      {(isAdmin || canApproveOrReject) && (
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">
+            대기중 멤버 ({pendingTotalElements})
+          </h4>
+
+          {pendingMembers.length > 0 ? (
+            <div className="space-y-3">
+              {pendingMembers.map((p) => (
+                <div
+                  key={p.memberId}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <Avatar profileImageUrl={p.profileImageUrl} />
+                    <div>
+                      <p className="text-sm font-medium text-black dark:text-white">
+                        {p.memberName}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {MEMBER_GRADE_LABELS[p.memberGrade]}
+                      </p>
+                    </div>
+                  </div>
+
+                  {(isAdmin || canApproveOrReject) && (
+                    <CCParticipantActionButtons
+                      memberId={p.memberId}
+                      dataId={dataId}
+                      onApprove={() => handleApprove(p)}
+                      onReject={() => handleReject(p.memberId)}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 text-center">
+              대기중인 멤버가 없습니다.
+            </p>
+          )}
+
+          {pendingTotalPages > 1 && (
+            <Pagination
+              page={pendingPage}
+              totalPages={pendingTotalPages}
+              onChange={handlePendingPageChange}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// 아바타 컴포넌트
+function Avatar({ profileImageUrl }: { profileImageUrl?: string }) {
+  return (
+    <div className="relative w-8 h-8 rounded-full overflow-hidden bg-gray-200">
+      {profileImageUrl ? (
+        <Image
+          src={profileImageUrl}
+          alt="프로필"
+          fill
+          className="object-cover"
+        />
+      ) : (
+        <LogoSVG className="w-8 h-8 text-gray-400" />
+      )}
+    </div>
+  );
+}
+
+// 페이지네이션 버튼 컴포넌트
+function Pagination({
+  page,
+  totalPages,
+  onChange,
+}: {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+}) {
+  return (
+    <div className="flex justify-center items-center gap-1 mt-1 mb-4">
+      {/* 이전 버튼 */}
+      <button
+        onClick={() => onChange(page - 1)}
+        disabled={page === 0}
+        className={`p-1 rounded-md ${
+          page === 0
+            ? "text-gray-400 cursor-not-allowed"
+            : "text-gray-600 hover:bg-gray-100"
+        }`}
+      >
+        <ChevronLeft className="w-3 h-3" />
+      </button>
+
+      {[...Array(totalPages)].map((_, i) => (
+        <button
+          key={i}
+          onClick={() => onChange(i)}
+          className={`w-6 h-6 text-xs font-medium rounded-md border transition-colors ${
+            i === page
+              ? "bg-cert-red text-white border-cert-red"
+              : "border-gray-300 text-gray-700 hover:bg-gray-100"
+          }`}
+        >
+          {i + 1}
+        </button>
+      ))}
+
+      {/* 다음 버튼 */}
+      <button
+        onClick={() => onChange(page + 1)}
+        disabled={page + 1 === totalPages}
+        className={`p-1 rounded-md ${
+          page + 1 === totalPages
+            ? "text-gray-400 cursor-not-allowed"
+            : "text-gray-700 hover:bg-gray-100"
+        }`}
+      >
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/CCParticipantActionButtons.tsx
+++ b/src/components/ui/CCParticipantActionButtons.tsx
@@ -18,13 +18,19 @@ import {
   rejectAdminProjectParticipant,
 } from "@/app/api/admin/project/CCAdminProjectParticipantApi";
 
+interface CCParticipantActionButtonsProps {
+  memberId: number;
+  dataId: number;
+  onApprove?: () => void;
+  onReject?: () => void;
+}
+
 export default function CCParticipantActionButtons({
   memberId,
   dataId,
-}: {
-  memberId: number;
-  dataId: number;
-}) {
+  onApprove,
+  onReject,
+}: CCParticipantActionButtonsProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -49,9 +55,10 @@ export default function CCParticipantActionButtons({
           await approveProjectParticipant(memberId, dataId);
         }
       }
+      if (onApprove) onApprove();
       router.refresh();
-    } catch (err) {
-      throw err;
+    } catch (error) {
+      throw error;
     }
   };
 
@@ -71,9 +78,10 @@ export default function CCParticipantActionButtons({
           await rejectProjectParticipant(memberId, dataId);
         }
       }
+      if (onReject) onReject();
       router.refresh();
-    } catch (err) {
-      throw err;
+    } catch (error) {
+      throw error;
     }
   };
 

--- a/src/types/admin/adminMembers.ts
+++ b/src/types/admin/adminMembers.ts
@@ -13,4 +13,5 @@ export interface AdminMemberDetailInfoType extends MembersDataType {
   penaltyPoints: number;
   grade: string;
   memberId: number;
+  createdAt: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #105, #106 

## 📝작업 내용

> - Admin members 에서 멤버 정보를 CSV, xls, xlsx 파일로 추출하는 기능을 구현했습니다.
> - 모든 스터디원이 표시가 안되는 에러를 페이지네이션 기능을 통해 수정했습니다.
>   - Study / Project 승인된 부원 및 대기중인 부원 리스트를 페이지네이션 기능을 통해 10명 이상이라면 다음 페이지로 넘어갈 수 있도록 구현했습니다.
>   - 스터디원/프로젝트원 페이지네이션을 위해 Client Component로 분리했습니다.

### 스크린샷 (선택)
- csv 추출
<img width="217" height="58" alt="image" src="https://github.com/user-attachments/assets/351cceca-5982-4cbe-9b0d-939fcd7ec99e" />

<img width="1517" height="981" alt="csv 예시" src="https://github.com/user-attachments/assets/d1bdbdd4-1663-4a9a-aeea-5ef5a404799d" />

- 스터디원 페이지네이션
  - Study
  
     https://github.com/user-attachments/assets/f6845790-117f-4525-aa95-5c421ce99335

  - Project

      https://github.com/user-attachments/assets/893dabd8-ab59-4a05-87be-f510651611b0


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
