### PR TITLE
Fix: Covering error of the prose attribute

### DIFF
--- a/src/app/(main)/blog/[id]/page.tsx
+++ b/src/app/(main)/blog/[id]/page.tsx
@@ -148,7 +148,7 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
 
           {/* 본문 */}
           <div className="p-8">
-            <div className="prose prose-lg max-w-none">
+            <div className="max-w-none">
               {blogData.content ? (
                 <>
                   {/* 실제 마크다운 내용이 들어갈 곳 */}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #126 

## 📝작업 내용

> 블로그 페이지만 배포된 환경에서 css속성이 잘 동작하지않을 것을 보고 blog 페이지 css를 까봤습니다 

prose는 
마크다운(Markdown)이나 CMS 등 제어하기 어려운 HTML 콘텐츠에 자동으로 보기 좋은 타이포그래피 스타일(폰트 크기, 줄 간격, 여백 등)을 적용해주는 클래스이나  강제로 스타일을 기본 요소로 덮어씌워버리는 문제가 있습니다.
이번 Toast Ui를 사용하면서 스타일 충돌이 일어났습니다. 

### 스크린샷 (선택)
변경전
<img width="1602" height="894" alt="image" src="https://github.com/user-attachments/assets/23f5522d-7d09-44f4-9ca7-cbe5a008b7cc" />


변경후

<img width="1602" height="894" alt="image" src="https://github.com/user-attachments/assets/d9fbe9d6-3bcf-4950-9967-d3368e9e1ae4" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
