### PR TITLE
Fix: xss 취약점 제거

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/page.tsx
@@ -8,6 +8,7 @@ import KebabMenuButton from "@/components/detail/CCKebabMenu";
 import ShareButton from "@/components/detail/CCShareButton";
 import BackToListButton from "@/components/detail/SCBackToListButton";
 import DefaultBadge from "@/components/ui/defaultBadge";
+import MarkdownRenderer from "@/components/ui/defaultMarkdownRenderer";
 import { Calendar, ExternalLink, Eye, User } from "lucide-react";
 
 interface BlogDetailPageProps {
@@ -53,10 +54,9 @@ export default async function AdminBlogDetailPage({
 }: BlogDetailPageProps) {
   const resolvedParams = await params;
   const blogId = parseInt(resolvedParams.id, 10);
-  console.log(blogId);
-  const post: BlogDetailDataType = await searchBlogDetail(blogId);
+  const blogData: BlogDetailDataType = await searchBlogDetail(blogId);
 
-  if (!post) {
+  if (!blogData) {
     notFound();
   }
 
@@ -67,19 +67,20 @@ export default async function AdminBlogDetailPage({
 
       {/* 메인 콘텐츠 */}
       <article className="rounded-lg border border-gray-200 overflow-hidden shadow-lg p-4 mt-6 dark:bg-gray-800 dark:border-gray-700">
-        {/* 헤더 */}
-        <header className="p-8 border-b border-gray-200 dark:border-gray-700">
-          {/* 카테고리와 케밥 메뉴 */}
+        {/* 헤더: 원본 코드의 반응형 패딩 사용 */}
+        <header className="p-4 sm:p-6 lg:p-8 border-b border-gray-200 dark:border-gray-700">
+          {/* 카테고리와 케밥 메뉴: 원본 레이아웃 유지하며 관리자용 버튼/태그 추가 */}
           <div className="flex items-start justify-between mb-4">
             <div className="flex items-center gap-2">
               <DefaultBadge
                 variant="custom"
-                className={getCategoryColor(post.category)}
+                className={`${getCategoryColor(blogData.category)} cursor-default`}
               >
-                {post.category}
+                {blogData.category}
               </DefaultBadge>
 
-              {post.isPublic ? (
+              {/* 관리자 전용 공개/비공개 태그 유지 */}
+              {blogData.isPublic ? (
                 <DefaultBadge
                   variant="outline"
                   className="bg-blue-200 text-blue-600 border-blue-300"
@@ -105,70 +106,71 @@ export default async function AdminBlogDetailPage({
           </div>
 
           {/* 제목 */}
-          <h1 className="text-3xl font-bold text-gray-900 mb-4 leading-tight dark:text-gray-200">
-            {post.title}
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-6 leading-tight dark:text-gray-200">
+            {blogData.title}
           </h1>
 
           {/* 요약 */}
-          {post.description && (
-            <p className="text-lg text-gray-600 mb-3 leading-relaxed dark:text-gray-300">
-              {post.description}
+          {blogData.description && (
+            <p className="text-base sm:text-lg text-gray-600 mb-3 leading-relaxed dark:text-gray-300">
+              {blogData.description}
             </p>
           )}
 
-          {/* 참조 (스터디/프로젝트) */}
-          {post.referenceType && post.referenceTitle && (
+          {/* 참조 */}
+          {blogData.referenceType && blogData.referenceTitle && (
             <div className="mb-3">
               <div
-                className={`inline-flex items-center px-3 py-1 text-sm font-medium rounded-md transition-colors
+                className={`inline-flex items-center px-2.5 sm:px-3 py-1 text-xs sm:text-sm font-medium rounded-md transition-colors
         ${
-          post.referenceType === "STUDY"
+          blogData.referenceType === "STUDY"
             ? "badge-green hover:bg-green-100 hover:text-green-800"
             : "badge-blue hover:bg-blue-100 hover:text-blue-800"
         }`}
               >
-                {post.referenceType === "STUDY" ? "스터디" : "프로젝트"} ·{" "}
-                {post.referenceTitle}
+                {blogData.referenceType === "STUDY" ? "스터디" : "프로젝트"} ·{" "}
+                {blogData.referenceTitle}
               </div>
             </div>
           )}
 
           {/* 메타 정보 */}
-          <div className="flex flex-wrap items-center gap-6 text-sm text-gray-600 dark:text-gray-300">
-            <div className="flex items-center gap-2">
-              <User className="w-4 h-4" />
-              <span>{post.creatorName}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Calendar className="w-4 h-4" />
-              <span>{formatDate(post.createdAt)}</span>
-            </div>
-            {post.viewCount !== null && (
-              <div className="flex items-center gap-2">
-                <Eye className="w-4 h-4" />
-                <span>{post.viewCount.toLocaleString()}</span>
+          <div className="flex flex-wrap items-center text-xs sm:text-sm text-gray-600 justify-between dark:text-gray-300">
+            <div className="flex flex-row gap-4 sm:gap-6">
+              <div className="flex items-center gap-1.5 sm:gap-2">
+                <User className="w-4 h-4" />
+                <span>{blogData.creatorName}</span>
               </div>
-            )}
+              <div className="flex items-center gap-1.5 sm:gap-2">
+                <Calendar className="w-4 h-4" />
+                <span>{formatDate(blogData.createdAt)}</span>
+              </div>
+              {blogData.viewCount !== null && (
+                <div className="flex items-center gap-1.5 sm:gap-2">
+                  <Eye className="w-4 h-4" />
+                  <span>{blogData.viewCount.toLocaleString()}</span>
+                </div>
+              )}
+            </div>
           </div>
         </header>
 
         {/* 본문 */}
         <div className="p-8">
-          <div className="prose prose-lg max-w-none">
-            {post.content ? (
-              <div
-                className="text-gray-800 leading-relaxed dark:border-gray-700"
-                dangerouslySetInnerHTML={{ __html: post.content }}
-              />
+          <div className="max-w-none">
+            {blogData.content ? (
+              <div className="max-w-none mb-8 pt-6 border-gray-300 dark:border-gray-700">
+                <MarkdownRenderer content={blogData.content} />
+              </div>
             ) : (
               <div className="text-gray-800 leading-relaxed whitespace-pre-wrap">
-                {post.description || "게시글 내용이 없습니다."}
+                {blogData.description || "게시글 내용이 없습니다."}
               </div>
             )}
           </div>
 
           <div className="pt-6 border-t border-gray-200 flex justify-end dark:border-gray-700">
-            <ShareButton />
+            <ShareButton></ShareButton>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #138 

## 📝작업 내용

>  준상님 께서 발견하신 xss 취약점이 나타난 /admin/blog 도메인의 문제점을 찾았습니다.
기존 프로젝트는 어디까지나 기술 블로그 혹은 프로젝트나 스터디를 통해 사용한 스크립트를 어느정도 남겨야합니다
따라서 백엔드에 필터나 제거없이 저장이 가능하고 프론트 단에서 해당 스크립트가 동작하지 않도록 만들어야 합니다.
우리가 기본적으로 리액트에서 쓰는 {} 태그안에 내용은 자동적으로 악성 스크립트를 치환 제거를 합니다.
Toast UI 또한 에디터 혹은 뷰에서 스크립트를 출력할시에 자동 스크립트 치환 제거 동작을 수행합니다.

문제는 무엇이었나?

> dangerouslySetInnerHTML 속성은 입력한 스크립트를 innerHTML로 그대로 변환하므로 스크립트가 실행됩니다. (이건 거의뭐 xss하라고 열어둔 정도죠) 결론적으로 dangerously를 붙인 만큼 개발자가 직접 입력값을 매핑하거나 제거를 해주어야하는데 저는 그냥 썼습니다. 죄송합니다.

### 스크린샷 (선택)

<img width="1145" height="326" alt="image" src="https://github.com/user-attachments/assets/257cc4f9-d847-4795-b325-c20215b4682a" />


## 💬리뷰 요구사항(선택)

> 미안합니다
